### PR TITLE
Fix the snippet for adding TelerikRootComponent

### DIFF
--- a/_contentTemplates/common/get-started.md
+++ b/_contentTemplates/common/get-started.md
@@ -177,21 +177,21 @@ Open the main layout file (by default, the `~/Shared/MainLayout.razor` file in t
         @inherits LayoutComponentBase
         
         <TelerikRootComponent>
-        
-            <div class="sidebar">
-                <NavMenu />
+            <div class="page">
+              <div class="sidebar">
+                  <NavMenu />
+              </div>
+          
+              <div class="main">
+                  <div class="top-row px-4">
+                      <a href="https://docs.microsoft.com/en-us/aspnet/" target="_blank">About</a>
+                  </div>
+          
+                  <div class="content px-4">
+                      @Body
+                  </div>
+              </div>
             </div>
-        
-            <div class="main">
-                <div class="top-row px-4">
-                    <a href="https://docs.microsoft.com/en-us/aspnet/" target="_blank">About</a>
-                </div>
-        
-                <div class="content px-4">
-                    @Body
-                </div>
-            </div>
-        
         </TelerikRootComponent>
 #end
 


### PR DESCRIPTION
When following the [First Steps with Server-Side UI for Blazor](https://docs.telerik.com/blazor-ui/getting-started/server-blazor) tutorial and applying it to default Blazor on .NET 5.0 RC2, I found out that the snippet for adding `<TelerikRootComponent>` will break the layout of the page.

`MainLayout.cs` needs the top-level `div` to have class `page`, otherwise the page content will be displayed below the menu (which only affects the desktop view of the page).