### PR TITLE
chore(form):clarification for the Enabled parameter of the FormIem

### DIFF
--- a/components/form/formitems/overview.md
+++ b/components/form/formitems/overview.md
@@ -27,8 +27,9 @@ The `FormItem` tag exposes the following parameters which you can use to customi
 
 * `Id` - `string` - maps to the `id` HTML attribute of the `<input>` tag.
 
-* `Hint` - `string` - defines a hint for the user on the place of the validation message. If a validation error occurs the hint will be replaced by the corresponding validation message. 
-* `Enabled` - `bool` - whether the editor is disabled. Defaults to `true` and the Form takes its value from the `[Enabled]` data annotation attribute.
+* `Hint` - `string` - defines a hint for the user on the place of the validation message. If a validation error occurs the hint will be replaced by the corresponding validation message.
+
+* `Enabled` - `bool` - whether the editor is enabled. Defaults to `true`. If it is not specifically defined in the `FormItem` markup, it will take its value from the `[Editable]` data annotation attribute of the item.
 
 * `Field` - `string` - the name of the field in the model that the editor will render for as a string (case-sensitive). You can set its as a plain string (`Field="SomeField"`) or to have .NET extract the field name from the model for flat models (`Field=@nameof(MyModelClass.SomeFIeld)`). If you are using its [Template]({%slug form-formitems-template%}) to provide a custom editor, the `Field` parameter is not required.
 

--- a/components/form/overview.md
+++ b/components/form/overview.md
@@ -186,7 +186,7 @@ The Form also uses the the following attributes from the model:
 
 * `[Display(Name="Field Caption")]` - to get the title (caption) of the field name to render out as its label. 
 
-* `[Enabled(false)]` - to render the built-in editor as disabled so the user cannot change its value.
+* `[Editable(false)]` - to render the built-in editor as disabled so the user cannot change its value.
 
 You can customize the editors further through the [form items]({%slug form-formitems%}). Explicit settings you provide through the parameters will take precedence over data annotation attributes.
 


### PR DESCRIPTION
Improvement based on the following customer feedback from 21 Jun 2021 8:07 PM:
"This statement is confusing: Enabled - bool - whether the editor is disabled. Defaults to true and the Form takes its value from the [Enabled] data annotation attribute. Do you mean the [Editable] data annotation attribute?"