### PR TITLE
Grid Header Template fix and kb linking

### DIFF
--- a/components/grid/templates/column-header.md
+++ b/components/grid/templates/column-header.md
@@ -12,7 +12,7 @@ position: 20
 
 Bound columns render the name of the field or their `Title` in their header. Through the `HeaderTemplate`, you can define custom content there instead of the title text.
 
->tip If you only want to center and wrap the column header text, you can achieve that with some custom CSS as shown in [this knowledge base article]({%slug grid-kb-center-column-header-content%}).
+>tip If you only want to center or wrap and center the column header text, you can achieve that with some custom CSS. You can try one of the following approaches depending on the desired result - [Center Grid Column Header content]({%slug grid-kb-center-column-header-content%}) or [Wrap and center the Grid column header text]({%slug grid-kb-wrap-and-center-column-header-text%}).
 
 >caption Sample Header Template
 

--- a/components/grid/templates/column-header.md
+++ b/components/grid/templates/column-header.md
@@ -12,7 +12,7 @@ position: 20
 
 Bound columns render the name of the field or their `Title` in their header. Through the `HeaderTemplate`, you can define custom content there instead of the title text.
 
->tip If you only want to center or wrap and center the column header text, you can achieve that with some custom CSS. You can try one of the following approaches depending on the desired result - [Center Grid Column Header content]({%slug grid-kb-center-column-header-content%}) or [Wrap and center the Grid column header text]({%slug grid-kb-wrap-and-center-column-header-text%}).
+>tip If you only want to center or wrap the column header text, you can achieve that with some custom CSS. You can try one of the following approaches depending on the desired result - [Center Grid Column Header content]({%slug grid-kb-center-column-header-content%}) or [Wrap and center the Grid column header text]({%slug grid-kb-wrap-and-center-column-header-text%}).
 
 >caption Sample Header Template
 
@@ -92,4 +92,3 @@ Bound columns render the name of the field or their `Title` in their header. Thr
 
  * [Live Demo: Grid Templates](https://demos.telerik.com/blazor-ui/grid/templates)
  * [Live Demo: Grid Custom Editor Template](https://demos.telerik.com/blazor-ui/grid/customeditor)
-

--- a/components/grid/templates/column-header.md
+++ b/components/grid/templates/column-header.md
@@ -12,6 +12,8 @@ position: 20
 
 Bound columns render the name of the field or their `Title` in their header. Through the `HeaderTemplate`, you can define custom content there instead of the title text.
 
+>tip If you only want to center and wrap the column header text, you can achieve that with some custom CSS as shown in [this knowledge base article]({%slug grid-kb-center-column-header-content%}).
+
 >caption Sample Header Template
 
 ````CSHTML
@@ -48,7 +50,7 @@ Bound columns render the name of the field or their `Title` in their header. Thr
         </GridColumn>
         <GridColumn>
             <HeaderTemplate>
-                <span class="k-display-flex k-align-items-center">
+                <span>
                     <TelerikIcon Icon="image" />
                     Column with Icon
                 </span>

--- a/knowledge-base/grid-center-column-header-content.md
+++ b/knowledge-base/grid-center-column-header-content.md
@@ -78,4 +78,4 @@ In order to center the content of the Grid column headers you can use some custo
 
 * If you need to wrap the column header content as well, you can try the approach from this knowledge base article - [Wrap and center the Grid Column Header text]({%slug grid-kb-wrap-and-center-column-header-text%}). It shows how to change the default display property of the header cells to `block` and then easily operate with their content to wrap and center it.
 
-* If you want full control over the header text contents and rendering, you can use the [column header template]({%slug grid-templates-column-header%}).
+* If you want full control over the header text contents and rendering, you can use a [column header template]({%slug grid-templates-column-header%}).

--- a/knowledge-base/grid-center-column-header-content.md
+++ b/knowledge-base/grid-center-column-header-content.md
@@ -5,7 +5,7 @@ type: how-to
 page_title: Center Grid Column Header content
 slug: grid-kb-center-column-header-content
 position: 
-tags: grid, column, header, center
+tags: telerik, blazor, grid, column, header, center
 ticketid: 
 res_type: kb
 ---
@@ -74,3 +74,8 @@ In order to center the content of the Grid column headers you can use some custo
 }
 ````
 
+## Notes
+
+* If you need to wrap the column header content as well, you can also try the approach demonstrated in this knowledge base article - [Wrap and center the Grid Column Header text]({%slug grid-kb-wrap-and-center-column-header-text%}). It showcases how to change the default display property of the header cells to `block` and then easily operate with their content to wrap and center it.
+
+* If you want full control over the header text contents and rendering, you can use the [column header template]({%slug grid-templates-column-header%}).

--- a/knowledge-base/grid-center-column-header-content.md
+++ b/knowledge-base/grid-center-column-header-content.md
@@ -76,6 +76,6 @@ In order to center the content of the Grid column headers you can use some custo
 
 ## Notes
 
-* If you need to wrap the column header content as well, you can also try the approach demonstrated in this knowledge base article - [Wrap and center the Grid Column Header text]({%slug grid-kb-wrap-and-center-column-header-text%}). It showcases how to change the default display property of the header cells to `block` and then easily operate with their content to wrap and center it.
+* If you need to wrap the column header content as well, you can try the approach from this knowledge base article - [Wrap and center the Grid Column Header text]({%slug grid-kb-wrap-and-center-column-header-text%}). It shows how to change the default display property of the header cells to `block` and then easily operate with their content to wrap and center it.
 
 * If you want full control over the header text contents and rendering, you can use the [column header template]({%slug grid-templates-column-header%}).

--- a/knowledge-base/grid-wrap-and-center-column-text.md
+++ b/knowledge-base/grid-wrap-and-center-column-text.md
@@ -1,11 +1,11 @@
 ---
-title: How to wrap and center the Grid column header text
-description: How to wrap and center the Grid column header text
+title: Wrap and center the Grid Column Header text
+description: How to wrap and center the Grid Column Header text
 type: how-to
-page_title: How to wrap and center the Grid column header text
+page_title: How to wrap and center the Grid Column Header text
 slug: grid-kb-wrap-and-center-column-header-text
 position: 
-tags: 
+tags: telerik, blazor, grid, column, header, wrap, center
 ticketid: 1507250
 res_type: kb
 ---
@@ -76,6 +76,8 @@ You can use some custom CSS that aligns text in the center and enables text wrap
 ````
 
 ## Notes
+
+* If you only need to center the header text content, you can also try the approach demonstrated in this knowledge base article - [Center Grid Column Header content]({%slug grid-kb-center-column-header-content%}). It allows you to keep the preset `display: flex` of the cells and simply justify their content to the center.
 
 * If you want full control over the header text contents and rendering, you can use the [column header template]({%slug grid-templates-column-header%}).
 

--- a/knowledge-base/grid-wrap-and-center-column-text.md
+++ b/knowledge-base/grid-wrap-and-center-column-text.md
@@ -77,7 +77,6 @@ You can use some custom CSS that aligns text in the center and enables text wrap
 
 ## Notes
 
-* If you only need to center the header text content, you can also try the approach demonstrated in this knowledge base article - [Center Grid Column Header content]({%slug grid-kb-center-column-header-content%}). It allows you to keep the preset `display: flex` of the cells and simply justify their content to the center.
+* If you only need to center the header text content, you can try the approach demonstrated in this knowledge base article - [Center Grid Column Header content]({%slug grid-kb-center-column-header-content%}). This will keep the preset `display: flex` style of the cells.
 
 * If you want full control over the header text contents and rendering, you can use the [column header template]({%slug grid-templates-column-header%}).
-


### PR DESCRIPTION
- Fixed snippet in Header Template article - the style was outdated.
- Linked kb-s for column header content center and wrap and center: to each other and from the Header Template article