### PR TITLE
chore(tilelayout,contextmenu): removed section for shouldrender flag …

### DIFF
--- a/components/contextmenu/events.md
+++ b/components/contextmenu/events.md
@@ -20,8 +20,6 @@ The `OnClick` event fires when the user clicks or taps on a menu item. It receiv
 
 You can use the `OnClick` event to react to user choices in a menu without using navigation to load new content automatically.
 
-@[template](/_contentTemplates/common/general-info.md#rerender-after-event)
-
 >caption Handle OnClick
 
 ````CSHTML

--- a/components/tilelayout/events.md
+++ b/components/tilelayout/events.md
@@ -19,8 +19,6 @@ This article explains the events available in the Telerik TileLayout for Blazor:
 
 The `OnResize` event is fired when any tile is resized. It lets you respond to that change if needed - for example, call the `.Refresh()` method of a chart or otherwise repaint a child component in the content. You can also use it to, for example, update the saved [state]({%slug tilelayout-state%}) for your users.
 
-@[template](/_contentTemplates/common/general-info.md#rerender-after-event)
-
 >caption Respond to the Resize event and adjust components in the tile
 
 ````CSHTML
@@ -84,8 +82,6 @@ The `OnResize` event is fired when any tile is resized. It lets you respond to t
 ## OnReorder
 
 The `OnReorder` event fires when tiles have been reordered. You can use it to, for example, update the saved [state]({%slug tilelayout-state%}) for your users.
-
-@[template](/_contentTemplates/common/general-info.md#rerender-after-event)
 
 >caption Respond to the OnReorder event
 


### PR DESCRIPTION
Removed sections for ShouldRender flag in the:

- TileLayout
- ContextMenu

Because of https://github.com/telerik/blazor/issues/1556#issuecomment-817499307