### PR TITLE
docs(grid): public getter and setter needed

### DIFF
--- a/components/grid/columns/bound.md
+++ b/components/grid/columns/bound.md
@@ -129,7 +129,7 @@ You can use the following properties on bound columns:
     * If the `Field` points to a custom object or something like an `IDictionary`, `List`, and `Array` errors will be thrown upon those actions because there are no known data operations on non-primitive types in .NET. To handle such scenarios you could flatten the collection and the underlying model. 
     * To bind to nested (complex) models (also called navigation properties), use only the name of the field that holds the child class and its own field. For an example, see the [Bind to navigation properties in complex objects]({%slug grid-use-navigation-properties%}) article.
 
-* The `Field` must have a public getter so that the grid can display data. For editing to be enabled, there must be a public setter. For example
+* The `Field` of the column must point to a property in the model that has a public getter so that the grid can display data. For editing to be enabled, the property must have a public setter. For example:
 
     **C#**
         public class MyModel


### PR DESCRIPTION
Actually, this applies to literally all fields (properties) our components use, both databound ones, and also applies to inputs for @bind-Value, for example.

Consider making the Notes section a template and copying it to the "Data Binding" article.