### PR TITLE
docs: Allow override of CTA message from blazor-docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -566,6 +566,9 @@ platform: blazor
 ## CTA panels on every page for trials
 has_cta_panels: true
 
+## CTA overrides for docs-seed
+cta_panels_data_overwrites:
+   message: "professional grade UI library with 90+ native components for building modern and feature-rich applications."
 
 ## Color Scheme
 main_theme: blazor


### PR DESCRIPTION
This change will allow us to change the CTA panel text from blazor-docs, instead of docs-seed.