### PR TITLE
docs: Switch .gitignore to Unix line endings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 /favicon.ico
 /fonts/
 /styles/
+CODEOWNERS
 Dockerfile
 Gemfile
 Gemfile.lock
@@ -40,6 +41,7 @@ bs-config.js
 build-docs.sh
 copy_content.sh
 copy_local.sh
+exclude.txt
 install-npm.sh
 knowledge-base.html
 modify-config.sh


### PR DESCRIPTION
Currently .gitignore has Windows line endings -

* The other files use Unix LE
* When I copy the docs-seed assets to the blazor-docs folder (`sh copy_local.sh ...`), this always marks the .gitignore file as changed.