### PR TITLE
kb(input): important update in the input keyboard events kb for the d…

### DIFF
--- a/knowledge-base/inputs-handle-keyboard-events.md
+++ b/knowledge-base/inputs-handle-keyboard-events.md
@@ -32,7 +32,7 @@ The keyboard events bubble up the DOM, so you can attach event handlers for them
 
 If you are looking for an event when the user confirms an action, consider the built-in `OnChange` event which fires when the user presses `Enter` or blurs the input.
 
->important Optionally, you can disable the [**`DebounceDelay`**](https://docs.telerik.com/blazor-ui/components/textbox/overview#:~:text=DebounceDelay,int) parameter of the textbox by setting it to 0. The `DebounceDelay` default value is 150. It can fire the `onkeypress` event logic before the [**`ValueChanged`**](https://docs.telerik.com/blazor-ui/components/textbox/events#valuechanged) event of the input. 
+>important Optionally, you can set the [**`DebounceDelay`**]({%slug components/textbox/overview%}#features) parameter of the textbox to 0. The `DebounceDelay` default value is 150. It can fire the `onkeypress` event logic before the [**`ValueChanged`**]({%slug components/textbox/events%}#valuechanged) event of the input. 
 
 >caption Handle keyboard events in Telerik inputs
 

--- a/knowledge-base/inputs-handle-keyboard-events.md
+++ b/knowledge-base/inputs-handle-keyboard-events.md
@@ -32,7 +32,7 @@ The keyboard events bubble up the DOM, so you can attach event handlers for them
 
 If you are looking for an event when the user confirms an action, consider the built-in `OnChange` event which fires when the user presses `Enter` or blurs the input.
 
->important Optionally, you can set the [**`DebounceDelay`**]({%slug components/textbox/overview%}#features) parameter of the textbox to 0. The `DebounceDelay` default value is 150. It can fire the `onkeypress` event logic before the [**`ValueChanged`**]({%slug components/textbox/events%}#valuechanged) event of the input. 
+>important Optionally, you can set the [**`DebounceDelay`**]({%slug components/textbox/overview%}#features) parameter of the textbox to 0. The `onkeypress` event logic will fire before the input [**`ValueChanged`**]({%slug components/textbox/events%}#valuechanged). In this case, the default delay can cause a mismatch in the events values.
 
 >caption Handle keyboard events in Telerik inputs
 

--- a/knowledge-base/inputs-handle-keyboard-events.md
+++ b/knowledge-base/inputs-handle-keyboard-events.md
@@ -32,13 +32,15 @@ The keyboard events bubble up the DOM, so you can attach event handlers for them
 
 If you are looking for an event when the user confirms an action, consider the built-in `OnChange` event which fires when the user presses `Enter` or blurs the input.
 
+>important Optionally, you can disable the [**`DebounceDelay`**](https://docs.telerik.com/blazor-ui/components/textbox/overview#:~:text=DebounceDelay,int) parameter of the textbox by setting it to 0. The `DebounceDelay` default value is 150. It can fire the `onkeypress` event logic before the [**`ValueChanged`**](https://docs.telerik.com/blazor-ui/components/textbox/events#valuechanged) event of the input. 
+
 >caption Handle keyboard events in Telerik inputs
 
 ````CSHTML
 @* Add a keyboard event handler on the parent element to capture the events *@
 
 <span @onkeypress="@KeyHandlerTb" @onkeydown="@KeyHandlerTb">
-    <TelerikTextBox @bind-Value="@TbValue"></TelerikTextBox>
+    <TelerikTextBox DebounceDelay="0" @bind-Value="@TbValue"></TelerikTextBox>
 </span>
 
 <span @onkeypress="@KeyHandlerNtb" @onkeydown="@KeyHandlerNtb">

--- a/knowledge-base/inputs-handle-keyboard-events.md
+++ b/knowledge-base/inputs-handle-keyboard-events.md
@@ -32,7 +32,7 @@ The keyboard events bubble up the DOM, so you can attach event handlers for them
 
 If you are looking for an event when the user confirms an action, consider the built-in `OnChange` event which fires when the user presses `Enter` or blurs the input.
 
->important Optionally, you can set the [**`DebounceDelay`**]({%slug components/textbox/overview%}#features) parameter of the textbox to 0. The `onkeypress` event logic will fire before the input [**`ValueChanged`**]({%slug components/textbox/events%}#valuechanged). In this case, the default delay can cause a mismatch in the events values.
+>important Optionally, you can set the [**`DebounceDelay`**]({%slug components/textbox/overview%}#features) parameter of the textbox to 0. This can prevent textbox value mismatch in the `onkeypress` and [**`ValueChanged`**]({%slug components/textbox/events%}#valuechanged) event handlers. Such mismatch can occur due to the default `DebounceDelay` value.
 
 >caption Handle keyboard events in Telerik inputs
 


### PR DESCRIPTION
- Added note for the new DebounceDelay parameter in the KB for capturing input keyboard events. It is important because it can break many scenarios.