### PR TITLE
chore(grid):fixed wrong statement in validation

### DIFF
--- a/components/grid/editing/validation.md
+++ b/components/grid/editing/validation.md
@@ -10,7 +10,7 @@ position: 40
 
 # Grid Validation
 
-The Telerik UI for Blazor Grid supports built-in validation that is enabled by default. The Grid passes an `EditContext` as a cascading value to the editable cells. If any validation messages are present, the Grid will render them as [Validation Tooltips]({%slug validation-tools-tooltip%}) on hover of the specific editor. 
+The Telerik UI for Blazor Grid supports built-in validation that is enabled by default. The Grid passes an `EditContext` as a cascading value to the editable cells. When you use [inline]({%slug components/grid/editing/inline%}) or [incell]({%slug components/grid/editing/incell%}) editing, if any validation messages are present, the Grid will render them as [Validation Tooltips]({%slug validation-tools-tooltip%}) on hover of the edited input. 
 
 #### In this Article:
 


### PR DESCRIPTION
- Fixed wrong state for showing validation tooltip in Grid Popup edit mode. Currently, the tooltip works only for inline and incell modes.