### PR TITLE
docs(gantt): fixed broken link

### DIFF
--- a/components/gantt/gantt-tree/templates/editor.md
+++ b/components/gantt/gantt-tree/templates/editor.md
@@ -10,7 +10,7 @@ position: 15
 
 # Editor Template
 
-The column's `EditorTemplate` defines the inline template or component that will be rendered when the user is [editing](%slug gantt-tree-editing) the field. It is also used when inserting a new item. The template receives a copy of the model, so that changes can be cancelled with the `Cancel` command.
+The column's `EditorTemplate` defines the inline template or component that will be rendered when the user is [editing]({%slug gantt-tree-editing%}) the field. It is also used when inserting a new item. The template receives a copy of the model, so that changes can be cancelled with the `Cancel` command.
 
 You can data bind components in it to the current context, which is an instance to the model the Gantt is bound to. 
 


### PR DESCRIPTION
- Fixed broken link in editor template page 