### PR TITLE
Update disabled-button.md

### DIFF
--- a/components/button/disabled-button.md
+++ b/components/button/disabled-button.md
@@ -12,6 +12,8 @@ position: 5
 
 Sometimes specific buttons in an application must be temporarily disabled. To control the enabled state of the component, use the `Enabled` Boolean attribute.
 
+**Note:** The component's `OnClick` event handler does not validate its `Enabled` state before actually firing the event. Setting `Enabled` to false only affects the rendering of the HTML button element by setting its `disabled` attribute. If this is removed via DOM manipulation the button can still be clicked and the event will be fired.
+
 The following example demonstrates how to enable and disable the Button.
 
 >caption Toggle Telerik Button Enabled State


### PR DESCRIPTION
This is meant to clarify that a developer is still responsible to verify the button's "Enabled" state in the "OnClick" event handler.

For further details see https://feedback.telerik.com/blazor/1555442-telerikbutton-disabled-state-can-be-circumvented-to-trigger-onclick