### PR TITLE
docs(common): Add common Data Binding section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,6 +33,9 @@ navigation:
      "common-features":
         title: "Common Features"
         position: 15
+     "common-features/data-binding":
+        title: "Data Binding"
+        position: 0
      "globalization":
         title: "Globalization"
         position: 16

--- a/_config.yml
+++ b/_config.yml
@@ -642,6 +642,12 @@ defaults:
         title_prefix_separator: " "
 -
     scope:
+        path: "common-features/data-binding"
+    values:
+        title_prefix: ""
+        title_prefix_separator: ""
+-
+    scope:
         path: "globalization"
     values:
         title_prefix: "Blazor"
@@ -666,7 +672,7 @@ defaults:
         category: "default"
         product: "blazor"
         editable: true
-        description_suffix: "Read more in our Blazor Knowledgebase articles."
+        description_suffix: "Read more in our Blazor Knowledge Base articles."
 
 #- 
 #    scope:

--- a/_contentTemplates/common/get-started.md
+++ b/_contentTemplates/common/get-started.md
@@ -128,7 +128,9 @@ Next, you can explore the [live demos](https://demos.telerik.com/blazor-ui/) and
 
 Many applications have a data grid component, and you can get started with the full-featured Telerik Grid by visiting the [Grid Overview]({%slug grid-overview%}) article.
 
-You can also explore the [List of Components]({%slug blazor-overview%}#list-of-components) and pick the ones you are interested in.
+We recommend to get familiar with the [fundametals of data binding our components]({%slug common-features-data-binding-overview}). This information is applicable for all databound components.
+
+Finally, you can explore the [List of Components]({%slug blazor-overview%}#list-of-components) and pick the ones you are interested in.
 #end
 
 #demos-project-net-version

--- a/_contentTemplates/common/get-started.md
+++ b/_contentTemplates/common/get-started.md
@@ -128,7 +128,7 @@ Next, you can explore the [live demos](https://demos.telerik.com/blazor-ui/) and
 
 Many applications have a data grid component, and you can get started with the full-featured Telerik Grid by visiting the [Grid Overview]({%slug grid-overview%}) article.
 
-We recommend to get familiar with the [fundametals of data binding our components]({%slug common-features-data-binding-overview}). This information is applicable for all databound components.
+We recommend to get familiar with the [fundametals of data binding our components]({%slug common-features-data-binding-overview%}). This information is applicable for all databound components.
 
 Finally, you can explore the [List of Components]({%slug blazor-overview%}#list-of-components) and pick the ones you are interested in.
 #end

--- a/common-features/data-binding/observable-data.md
+++ b/common-features/data-binding/observable-data.md
@@ -1,6 +1,6 @@
 ---
 title: Observable Data
-page_title: Observable Collection
+page_title: Databind to Observable Collection
 description: Support for live data through observable collections and INotifyCollectionChanged in Telerik UI for Blazor.
 slug: common-features-observable-data
 tags: telerik,blazor,observable,data,live,INotifyCollectionChanged 

--- a/common-features/data-binding/observable-data.md
+++ b/common-features/data-binding/observable-data.md
@@ -5,7 +5,7 @@ description: Support for live data through observable collections and INotifyCol
 slug: common-features-observable-data
 tags: telerik,blazor,observable,data,live,INotifyCollectionChanged 
 published: True
-position: 1
+position: 10
 ---
 
 # Observable Data and Refresh Data

--- a/common-features/data-binding/observable-data.md
+++ b/common-features/data-binding/observable-data.md
@@ -30,7 +30,7 @@ In this article:
 
 ## Telerik components that support Observable Data
 
-The following components support observable data for their `Data` parameter. Note that obserable data is not supported with manual data binding via the `OnRead` event.
+The following components support observable data for their `Data` parameter. Note that observable data is not supported with manual data binding via the `OnRead` event.
 
 * [AutoComplete]({%slug autocomplete-refresh-data%})
 

--- a/common-features/data-binding/onread.md
+++ b/common-features/data-binding/onread.md
@@ -82,7 +82,6 @@ The event argument object has the following properties:
 | `Request` | [`DataSourceRequest`](/blazor-ui/api/Telerik.DataSource.DataSourceRequest) | This object carries information about the requested data items. It will reveal the page index or virtual scroll offset, the sorting and filtering state, etc. |
 | `Data` | `IEnumerable` | Set it to the **chunk** of data items, which the component will **render**. |
 | `Total` | `int` | Set it to the **total number** of items. This value will help the component generate its **pager** or **virtual scrollbar** correctly. |
-| `AggregateResults` | [`IEnumerable<AggregateResult>`](/blazor-ui/api/Telerik.DataSource.AggregateResult) | This property exists only in the [`GridReadEventArgs`](/blazor-ui/api/Telerik.Blazor.Components.GridReadEventArgs) type for the Grid. Set it to aggregate values for the whole data. |
 
 >caption Using DataSourceRequest properties
 

--- a/common-features/data-binding/onread.md
+++ b/common-features/data-binding/onread.md
@@ -1,6 +1,6 @@
 ---
 title: OnRead Event
-page_title: Databind using the OnRead Event
+page_title: Databind with the OnRead Event
 description: How to data bind Telerik Blazor components with the OnRead event. How to load data on demand.
 slug: common-features-data-binding-onread
 tags: telerik,blazor,binding,databinding,onread

--- a/common-features/data-binding/onread.md
+++ b/common-features/data-binding/onread.md
@@ -43,7 +43,7 @@ Large amounts of data require loading in chunks and on demand. This improves the
 
 `OnRead` enables [data binding to **OData** services]({%slug common-kb-odata%}).
 
-In general, `OnRead` allows the application to know the exact data items, which the user is currently seeing.
+`OnRead` also allows the application to know the exact data items, which the user is currently seeing.
 
 
 ## Components with OnRead Event

--- a/common-features/data-binding/onread.md
+++ b/common-features/data-binding/onread.md
@@ -30,7 +30,7 @@ There are two main reasons to use the `OnRead` event: **performance** and **cust
 
 Large amounts of data require loading in chunks and on demand. This improves the performance of the database, backend, network, and the browser. When a component fires `OnRead`, it expects to receive **only the data items to render**. The exact number depends on the component's `PageSize` parameter.
 
-`OnRead` makes it possible to perform data operations outside the Grid, for example on the remote server. This can improve WebAssembly performance.
+`OnRead` also offloads data operations outside the component, for example on the remote server. This can improve WebAssembly application performance.
 
 ### Customization
 
@@ -48,16 +48,18 @@ In general, `OnRead` allows the application to know the exact data items, which 
 
 ## Components with OnRead Event
 
-The following Blazor components expose an `OnRead` event. All of them also feature virtualization, except the **ListView**, because it relies on custom templates for data visualization.
+The following Blazor components expose an `OnRead` event. To gain **performance** benefits, use the event together with **paging** or **virtualization** (also called virtual scrolling).
 
-Each link points to component-specific `OnRead` documentation and examples:
+Each component name points to component-specific `OnRead` documentation and examples:
 
-* [AutoComplete]({%slug autocomplete-events%}#onread)
-* [ComboBox]({%slug components/combobox/events%}#onread)
-* [DropDownList]({%slug components/dropdownlist/events%}#onread)
-* [Grid]({%slug components/grid/manual-operations%})
-* [ListView]({%slug listview-manual-operations%})
-* [MultiSelect]({%slug multiselect-events%}#onread)
+| Component | Supports Paging | Supports Virtualization |
+| --- | --- | --- |
+| [AutoComplete]({%slug autocomplete-events%}#onread) | - | [AutoComplete virtualization]({%slug autocomplete-virtualization%}) |
+| [ComboBox]({%slug components/combobox/events%}#onread) | - | [ComboBox virtualization]({%slug combobox-virtualization%}) |
+| [DropDownList]({%slug components/dropdownlist/events%}#onread) | - | [DropDownList virtualization]({%slug dropdownlist-virtualization%}) |
+| [Grid]({%slug components/grid/manual-operations%}) | [Grid paging]({%slug components/grid/features/paging%}) | [Grid row virtualization]({%slug components/grid/virtual-scrolling%}) |
+| [ListView]({%slug listview-manual-operations%}) | [ListView paging]({%slug listview-paging%}) | - |
+| [MultiSelect]({%slug multiselect-events%}#onread) | - | [MultiSelect virtualization]({%slug multiselect-virtualization%}) |
 
 Components like the [**TreeList**]({%slug treelist-data-binding-load-on-demand%}) and the [**TreeView**]({%slug components/treeview/data-binding/load-on-demand%}) don't have an `OnRead` event. Instead, they load data on demand via `OnExpand` events.
 
@@ -77,10 +79,10 @@ The event argument object has the following properties:
 
 | Property | Type | Description |
 | --- | --- | --- |
-| `Request` | `DataSourceRequest` | This is the [`DataSourceRequest` object](/blazor-ui/api/Telerik.DataSource.DataSourceRequest), which carries information about the requested data items. It will reveal the page index or virtual scroll offset, the sorting and filtering state, etc. |
+| `Request` | [`DataSourceRequest`](/blazor-ui/api/Telerik.DataSource.DataSourceRequest) | This object carries information about the requested data items. It will reveal the page index or virtual scroll offset, the sorting and filtering state, etc. |
 | `Data` | `IEnumerable` | Set it to the **chunk** of data items, which the component will **render**. |
 | `Total` | `int` | Set it to the **total number** of items. This value will help the component generate its **pager** or **virtual scrollbar** correctly. |
-| `AggregateResults` | `IEnumerable<AggregateResult>` | This property is used only by the **Grid** and exists in the [`GridReadEventArgs`](/blazor-ui/api/Telerik.Blazor.Components.GridReadEventArgs) type. Set it to [aggregate values](/blazor-ui/api/Telerik.DataSource.AggregateResult) for the whole data. |
+| `AggregateResults` | [`IEnumerable<AggregateResult>`](/blazor-ui/api/Telerik.DataSource.AggregateResult) | This property exists only in the [`GridReadEventArgs`](/blazor-ui/api/Telerik.Blazor.Components.GridReadEventArgs) type for the Grid. Set it to aggregate values for the whole data. |
 
 >caption Using DataSourceRequest properties
 
@@ -105,7 +107,7 @@ async Task GridReadHandler(GridReadEventArgs args)
 
 ## ToDataSourceResult Method
 
-The `DataSourceRequest` object provides information about the needed data. The question is how to retrieve this data most easily. Sometimes `OnRead` data binding is called "manual", but in most cases it doesn't have to be manual at all. The solution is **`ToDataSourceResult`**.
+The [`DataSourceRequest` object](/blazor-ui/api/Telerik.DataSource.DataSourceRequest) provides information about the needed data. The question is how to retrieve this data most easily. Sometimes `OnRead` data binding is called "manual", but in most cases it doesn't have to be manual at all. The solution is **`ToDataSourceResult`**.
 
 The `ToDataSourceResult` extension method is able to extract the requested data items from `IEnumerable`, `IQueryable` and `DataTable`. The method is part of the [Telerik DataSource Extensions](/blazor-ui/api/Telerik.DataSource.Extensions.QueryableExtensions). It expects a `DataSourceRequest` argument.
 
@@ -138,6 +140,7 @@ async Task GridReadHandler(GridReadEventArgs args)
 
     args.Data = result.Data;
     args.Total = result.Total;
+    args.AggregateResults = result.AggregateResults; // Grid only
 }
 ````
 

--- a/common-features/data-binding/onread.md
+++ b/common-features/data-binding/onread.md
@@ -68,7 +68,7 @@ Components like the [**TreeList**]({%slug treelist-data-binding-load-on-demand%}
 
 The `OnRead` event handler receives an argument, which inherits from [`ReadEventArgs`](/blazor-ui/api/Telerik.Blazor.Components.ReadEventArgs). The exact type depends on the component. For example, the Grid handler receives `GridReadEventArgs`. The ComboBox handler receives `ComboBoxReadEventArgs`, and so on.
 
-The event argument object has the following properties:
+The following properties of the event argument object are common for all [components with an `OnRead` event](#components-with-onread-event). Other properties are discussed in component-specific articles.
 
 <style>
     article style + table {

--- a/common-features/data-binding/onread.md
+++ b/common-features/data-binding/onread.md
@@ -1,0 +1,260 @@
+---
+title: OnRead Event
+page_title: Databind using the OnRead Event
+description: How to data bind Telerik Blazor components with the OnRead event. How to load data on demand.
+slug: common-features-data-binding-onread
+tags: telerik,blazor,binding,databinding,onread
+published: True
+position: 5
+---
+
+# Databinding with the OnRead Event
+
+This article presents the `OnRead` event and describes how to use it to data bind Telerik Blazor components.
+
+#### In this article:
+
+* [Purpose and benefits of `OnRead`](#purpose-and-benefits)
+* [Step-by-step instructions to get started](#getting-started)
+* [Which Blazor components use `OnRead`](#components-with-onread-event)
+* [Description of the `OnRead` event argument](#event-argument)
+* [How to get data with the `ToDataSourceResult` method](#todatasourceresult-method)
+* [How to refresh component data when using `OnRead`](#refresh-data)
+
+
+## Purpose and Benefits
+
+The easiest way to provide data to a component is to set its `Data` parameter to some `IEnumerable`. This is straight-forward and familiar, but not scalable.
+
+Large amounts of data require loading in chunks and on demand. This improves the performance of the database, the backend, the network and the browser.
+
+<!-- 
+### Comparison with the Data Parameter
+
+Benefits of `Data`
+
+* Simplicity
+* The component performs all data operations internally (paging, sorting, filtering, grouping, aggregates, etc.).
+
+Benefits of `OnRead`
+
+* Flexibility and customization
+* The component relies on the application for all data operations.
+
+>warning Do not use the `OnRead` and `Data` together with the same component instance. This was possible only [before UI for Blazor version 3.0]({%slug changes-in-3-0-0%}#onread).
+
+-->
+
+## Getting Started
+
+1. Import the `Telerik.DataSource.Extensions` namespace.
+1. Set the component's `TItem` parameter to the model type.
+1. Set the component's `TValue` parameter to the value type. Does not apply to the Grid and ListView.
+1. Subscribe to the `OnRead` event.
+1. In the event handler, set the `Data` property of the event argument to the data items to render.
+1. Set the `Total` property of the event argument to the total number of data items.
+
+More information about [`args.Request`](#event-argument) and [`ToDataSourceResult`](#todatasourceresult-method) is available below.
+
+>caption Using the OnRead event
+
+````CSHTML
+@using Telerik.DataSource.Extensions
+
+<TelerikGrid TItem="@SampleModel"
+             OnRead="@OnGridRead"
+             AutoGenerateColumns="true"
+             Sortable="true"
+             Pageable="true"
+             FilterMode="@GridFilterMode.FilterRow" />
+
+@code {
+    List<SampleModel> GridData { get; set; }
+
+    async Task OnGridRead(GridReadEventArgs args)
+    {
+        var result = GridData.ToDataSourceResult(args.Request);
+
+        args.Data = result.Data;
+        args.Total = result.Total;
+    }
+
+    protected override void OnInitialized()
+    {
+        GenerateData();
+
+        base.OnInitialized();
+    }
+
+    void GenerateData()
+    {
+        GridData = new List<SampleModel>();
+
+        var rnd = new Random();
+
+        for (int i = 1; i <= 1000; i++)
+        {
+            GridData.Add(new SampleModel() { Id = i, Text = $"Text {rnd.Next(1, 100)}" });
+        }
+    }
+
+    public class SampleModel
+    {
+        public int Id { get; set; }
+        public string Text { get; set; }
+    }
+}
+````
+
+
+## Components with OnRead Event
+
+The following Telerik Blazor components expose an `OnRead` event. All of them also feature virtualization, except the ListView, because it always relies on custom templates for data visualization.
+
+Each link points to component-specific `OnRead` documentation and examples:
+
+* [AutoComplete]({%slug autocomplete-events%}#onread)
+* [ComboBox]({%slug components/combobox/events%}#onread)
+* [DropDownList]({%slug components/dropdownlist/events%}#onread)
+* [Grid]({%slug components/grid/manual-operations%})
+* [ListView]({%slug listview-manual-operations%})
+* [MultiSelect]({%slug multiselect-events%}#onread)
+
+Components like the [**TreeList**]({%slug treelist-data-binding-load-on-demand%}) and the [**TreeView**]({%slug components/treeview/data-binding/load-on-demand%}) don't have an `OnRead` event. Instead they can load data on demand via `OnExpand` events.
+
+
+## Event Argument
+
+The `OnRead` event handler will receive an argument, which inherits from [`ReadEventArgs`](/blazor-ui/api/Telerik.Blazor.Components.ReadEventArgs). The event argument object has the following properties:
+
+<style>
+    article style + table {
+        table-layout: auto;
+        word-break: normal;
+    }
+</style>
+
+| Property Name | Type | Description |
+| --- | --- | --- |
+| `Request` | `DataSourceRequest` | This is the [`DataSourceRequest` object](/blazor-ui/api/Telerik.DataSource.DataSourceRequest), which carries information about the requested data items. It will reveal the page index or virtual scroll offset, the sorting and filtering state, etc. |
+| `Data` | `IEnumerable` | Set it to the **chunk** of data items, which the component will **render**. |
+| `Total` | `int` | Set it to the **total number** of items. This value will help the component generate its **pager** or **virtual scrollbar** correctly. |
+| `AggregateResults` | `IEnumerable<AggregateResult>` | This property is used only by the **Grid** and exists in the [`GridReadEventArgs`](/blazor-ui/api/Telerik.Blazor.Components.GridReadEventArgs) type. Set it to [aggregate values](/blazor-ui/api/Telerik.DataSource.AggregateResult) for the whole data. |
+
+>tip The [`DataSourceRequest` object can be serialized and sent to the remote server](https://github.com/telerik/blazor-ui/tree/master/grid/datasourcerequest-on-server). **Use the `System.Text.Json` serializer**.
+
+
+## ToDataSourceResult Method
+
+The `DataSourceRequest` object provides information about the needed data. The question is how to retrieve this data most easily. Sometimes `OnRead` data binding is called "manual", but in most cases it doesn't have to be manual at all.
+
+The `ToDataSourceResult` extension method is able to extract the requested data items from `IEnumerable`, `IQueryable` and `DataTable`. The method is part of the [Telerik DataSource Extensions](/blazor-ui/api/Telerik.DataSource.Extensions.QueryableExtensions). It expects a `DataSourceRequest` argument.
+
+**`ToDataSourceResultAsync`** is the awaitable (asynchronous) alternative of `ToDataSourceResult`.
+
+>tip It is possible to use `DataSourceRequest`, `ToDataSourceResult` and `ToDataSourceResultAsync` in scenarios, which are not related to a specific Telerik component.
+
+
+## Refresh Data
+
+The components fire an `OnRead` event when the user performs an action, such as paging, sorting, virtual scrolling, etc. Calling the `OnRead` handler manually will not have effect, because the component will not be tracking the method arguments.
+
+All components with an `OnRead` event have a `Rebind` method as well. To refresh the component data programmatically, call this method. It will force the component to fire `OnRead` and receive new data.
+
+>caption Rebind DropDownList and Grid via OnRead
+
+````CSHTML
+@using Telerik.DataSource.Extensions
+
+<TelerikDropDownList @ref="@TheDropDown"
+                     TItem="@SampleModel"
+                     TValue="@int"
+                     OnRead="@OnDropDownRead"
+                     @bind-Value="@DropDownValue"
+                     ValueField="@nameof(SampleModel.Id)"
+                     TextField="@nameof(SampleModel.Text)"
+                     Width="200px">
+    <ValueTemplate>
+        @context.Id : @context.Text
+    </ValueTemplate>
+    <ItemTemplate>
+        @context.Id : @context.Text
+    </ItemTemplate>
+</TelerikDropDownList>
+
+<TelerikButton ThemeColor="@ThemeConstants.Button.ThemeColor.Primary"
+               OnClick="@RebindComponents">Rebind Components</TelerikButton>
+
+<br /><br />
+
+<TelerikGrid @ref="@TheGrid"
+             TItem="@SampleModel"
+             OnRead="@OnGridRead"
+             AutoGenerateColumns="true"
+             Sortable="true"
+             Pageable="true"
+             PageSize="5" />
+
+@code {
+    TelerikGrid<SampleModel> TheGrid { get; set; }
+    TelerikDropDownList<SampleModel, int> TheDropDown { get; set; }
+
+    List<SampleModel> GridData { get; set; }
+    List<SampleModel> DropDownData { get; set; }
+
+    int DropDownValue { get; set; } = 1;
+
+    void RebindComponents()
+    {
+        GenerateData(); // simulate change in the data
+
+        TheGrid.Rebind();
+        TheDropDown.Rebind();
+    }
+
+    async Task OnGridRead(GridReadEventArgs args)
+    {
+        var result = GridData.ToDataSourceResult(args.Request);
+        args.Data = result.Data;
+        args.Total = result.Total;
+    }
+
+    async Task OnDropDownRead(DropDownListReadEventArgs args)
+    {
+        var result = DropDownData.ToDataSourceResult(args.Request);
+        args.Data = result.Data;
+        args.Total = result.Total;
+    }
+
+    protected override void OnInitialized()
+    {
+        GenerateData();
+
+        base.OnInitialized();
+    }
+
+    void GenerateData()
+    {
+        GridData = new List<SampleModel>();
+        DropDownData = new List<SampleModel>();
+
+        var rnd = new Random();
+
+        for (int i = 1; i <= 10; i++)
+        {
+            GridData.Add(new SampleModel() { Id = i, Text = $"Text {rnd.Next(1, 100)}" });
+            DropDownData.Add(new SampleModel() { Id = i, Text = $"Text {rnd.Next(1, 100)}" });
+        }
+    }
+
+    public class SampleModel
+    {
+        public int Id { get; set; }
+        public string Text { get; set; }
+    }
+}
+````
+
+## See Also
+
+* [Using the Grid with OnRead]({%slug components/grid/manual-operations%})

--- a/common-features/data-binding/onread.md
+++ b/common-features/data-binding/onread.md
@@ -34,7 +34,7 @@ Large amounts of data require loading in chunks and on demand. This improves the
 
 ### Customization
 
-`OnRead` allows full control over the data operations. For example, it is possible to use custom sorting and filtering algoritms, if the built-in ones do not fit a given scenario. Here are just a few examples, but there are many more possible scenarios:
+`OnRead` allows full control over the data operations. For example, it is possible to use custom sorting and filtering algorithms, if the built-in ones do not fit a given scenario. Here are just a few examples, but there are many more possible scenarios:
 
 * [Search by multiple data fields in ComboBox and DropDownList]({%slug dropdowns-kb-search-in-multiple-fields%})
 * [Search in hidden Grid columns]({%slug grid-kb-search-in-hidden-fields%})

--- a/common-features/data-binding/onread.md
+++ b/common-features/data-binding/onread.md
@@ -12,14 +12,12 @@ position: 5
 
 This article presents the `OnRead` event and describes how to use it to data bind Telerik Blazor components.
 
-#### In this article:
-
 * [Purpose and benefits of `OnRead`](#purpose-and-benefits)
 * [Which Blazor components use `OnRead`](#components-with-onread-event)
 * [Description of the `OnRead` event argument](#event-argument)
 * [How to return data in `OnRead` with the `ToDataSourceResult` method](#todatasourceresult-method)
 * [Example](#example)
-* [How to refresh component data when using `OnRead`](#refresh-data)
+* [How to refresh the component data when using `OnRead`](#refresh-data)
 
 
 ## Purpose and Benefits

--- a/common-features/data-binding/overview.md
+++ b/common-features/data-binding/overview.md
@@ -10,10 +10,16 @@ position: 0
 
 # Data Binding Overview
 
-This article lists the different ways to provide data to the Telerik Blazor components. 
+This article lists the different ways to provide data to the Telerik Blazor components. For the sake of clarity, also check section [Value Binding vs Data Binding]({%slug get-started-value-vs-data-binding%}).
 
-## 
+## Fundamentals
+
+There are two main ways to provide data to Telerik Blazor components:
+
+* `Data` parameter - use it to provide all the data at once.
+* [`OnRead` event]({%slug common-features-data-binding-onread%}) - use it to load data on demand in chunks. 
 
 ## Next Steps
 
 * [Data Binding with the OnRead event]({%slug common-features-data-binding-onread%})
+* [Data Binding to Observable Data]({%slug common-features-observable-data%})

--- a/common-features/data-binding/overview.md
+++ b/common-features/data-binding/overview.md
@@ -1,0 +1,19 @@
+---
+title: Overview
+page_title: Data Binding Overview
+description: Learn the fundamentals and features of Telerik Blazor component data binding.
+slug: common-features-data-binding-overview
+tags: telerik,blazor,binding,databinding
+published: True
+position: 0
+---
+
+# Data Binding Overview
+
+This article lists the different ways to provide data to the Telerik Blazor components. 
+
+## 
+
+## Next Steps
+
+* [Data Binding with the OnRead event]({%slug common-features-data-binding-onread%})

--- a/common-features/data-binding/overview.md
+++ b/common-features/data-binding/overview.md
@@ -12,6 +12,11 @@ position: 0
 
 This article describes the fundamentals of data binding the Telerik Blazor components. For the sake of clarity, also check article [Value Binding vs Data Binding]({%slug get-started-value-vs-data-binding%}).
 
+* [Data binding options](#how-to-provide-data)
+* [Supported data types](#data-type)
+* [Model property names can matter](#model-property-names)
+* [How to refresh the component data](#refresh-data)
+
 
 ## How to Provide Data
 

--- a/common-features/data-binding/overview.md
+++ b/common-features/data-binding/overview.md
@@ -95,7 +95,7 @@ Some components handle properties with specific names in a predefined way. For e
 There are three ways to refresh the component data:
 
 * [Bind the component to Observable data]({%slug common-features-observable-data%}). **This option applies only** if the `Data` parameter is set. The component will refresh automatically when items are **added or removed**.
-* Call the component's `Rebind()` method, [if the component has it]({%slug common-features-data-binding-onread%}#components-with-onread-event). This method was implemented to be [used together with the `OnRead` event]({%slug common-features-data-binding-onread%}#refresh-data), but it works with `Data` too.
+* Call the component's `Rebind()` method, [if the component has it]({%slug common-features-data-binding-onread%}#components-with-onread-event). This method was implemented to be [used together with the `OnRead` event]({%slug common-features-data-binding-onread%}#refresh-data), but it works with `Data` too. Future UI for Blazor versions will expose the `Rebind()` method for all databound components.
 * Reset the `Data` parameter reference. In some specific scenarios, you may also need to call `StateHasChanged()`.
 
 The [example below](#example) demonstrates the second and third option.

--- a/common-features/data-binding/overview.md
+++ b/common-features/data-binding/overview.md
@@ -10,14 +10,71 @@ position: 0
 
 # Data Binding Overview
 
-This article lists the different ways to provide data to the Telerik Blazor components. For the sake of clarity, also check section [Value Binding vs Data Binding]({%slug get-started-value-vs-data-binding%}).
+This article describes the fundamentals of data binding the Telerik Blazor components. For the sake of clarity, also check article [Value Binding vs Data Binding]({%slug get-started-value-vs-data-binding%}).
 
-## Fundamentals
 
-There are two main ways to provide data to Telerik Blazor components:
+## How to Provide Data
+
+The Telerik Blazor components are detached from the application's data layer. They do not make data requests directly and rely on the application for data.
+
+There are two main ways to provide data to the components:
 
 * `Data` parameter - use it to provide all the data at once.
 * [`OnRead` event]({%slug common-features-data-binding-onread%}) - use it to load data on demand in chunks. 
+
+Hierarchy components like the TreeList and the TreeView don't have an `OnRead` event. Instead, they load data on demand via `OnExpand` events.
+
+>warning Do not use `Data` and `OnRead` at the same time with the same component.
+
+
+## Data Type
+
+All databound Telerik Blazor components expect their data to be `IEnumerable<T>`.
+
+All databound components are generic and their type depends on the model type. This is important when you need to define a component reference:
+
+>caption Defining reference to a databound component
+
+<div class="skip-repl"></div>
+
+````CS
+    // incorrect
+    private TelerikGrid Grid1 { get; set; }
+    private TelerikComboBox Combo1 { get; set; }
+
+    // correct
+    private TelerikGrid<SampleModel> Grid2 { get; set; }
+    private TelerikComboBox<SampleModel, int?> Combo2 { get; set; }
+````
+
+If the component `Data` is not set initially, set the `TItem` parameter to point to the model type. If the component has a `Value` parameter, then set `TValue` in this case as well.
+
+>caption Setting TItem and TValue
+
+<div class="skip-repl"></div>
+
+````CSHTML
+<TelerikGrid TItem="@SampleModel" />
+
+<TelerikComboBox TItem="@SampleModel"
+                 TValue="@(int?)"
+                 @bind-Value="@ComboValue" />
+
+@code {
+    int? ComboValue { get; set; }
+
+    public class SampleModel
+    {
+        public int Id { get; set; }
+        public int Text { get; set; }
+    }
+}
+````
+
+## Model Property Names
+
+Some components handle properties with specific names in a predefined way. For example, the Menu will automatically render the `Text` property of its items. If the property names are different, the component will expect additional configuration. All these specifics are described in each component documentation.
+
 
 ## Next Steps
 

--- a/common-features/data-binding/overview.md
+++ b/common-features/data-binding/overview.md
@@ -139,7 +139,7 @@ Thus, you will usually need to create a new reference for `Data` value in order 
             Text = "Text " + newId
         });
 
-        // components with an OnRead event have Rebind method:
+        // components with an OnRead event have a Rebind method:
         //GridRef.Rebind();
 
         // OR

--- a/common-features/data-binding/overview.md
+++ b/common-features/data-binding/overview.md
@@ -76,6 +76,56 @@ If the component `Data` is not set initially, set the `TItem` parameter to point
 Some components handle properties with specific names in a predefined way. For example, the Menu will automatically render the `Text` property of its items. If the property names are different, the component will expect additional configuration. All these specifics are described in each component documentation.
 
 
+## Refresh Data
+
+This section applies **only** if the `Data` parameter is set. Also check [how to refresh the data when using the `OnRead` event]({%slug common-features-data-binding-onread%}#refresh-data).
+
+There are two ways to refresh the component data:
+
+* [Bind the component to Observable data]({%slug common-features-observable-data%}). In this case, the component will refresh automatically when items are added or removed.
+* Reset the `Data` parameter reference. In some specific scenarios, you may also need to call `StateHasChanged()`.
+
+### Reset the Collection Reference
+
+The Blazor framework will fire `OnParametersSet` of a component only when it detects a change in the component's parameter values (such as `Data`). The change detection works like this:
+
+* For primitive types (numbers, strings, booleans), the detection occurs happens when the **value** changes.
+* For complex types (such as `IEnumerable` and any application-specific objects), the detection occurs when the **object reference** changes.
+
+Thus, you will usually need to create a new reference for `Data` value in order to refresh the component.
+
+>caption Create new Data reference
+
+<div class="skip-repl"></div>
+
+````CSHTML
+<TelerikGrid Data="@GridData" />
+
+@code {
+    List<SampleModel> GridData { get; set; }
+
+    void RefreshGridData()
+    {
+        // if the new items are not in GridData yet
+        GridData = new List<SampleModel>();
+        // manipulate GridData here...
+
+        // if the new items are already in GridData
+        GridData = new List<SampleModel>(GridData);
+
+        // call only if necessary
+        StateHasChanged();
+    }
+
+    public class SampleModel
+    {
+        public int Id { get; set; }
+        public int Text { get; set; }
+    }
+}
+````
+
+
 ## Next Steps
 
 * [Data Binding with the OnRead event]({%slug common-features-data-binding-onread%})

--- a/common-features/data-binding/overview.md
+++ b/common-features/data-binding/overview.md
@@ -96,7 +96,7 @@ There are three ways to refresh the component data:
 
 * [Bind the component to Observable data]({%slug common-features-observable-data%}). **This option applies only** if the `Data` parameter is set. The component will refresh automatically when items are **added or removed**.
 * Call the component's `Rebind()` method, [if the component has it]({%slug common-features-data-binding-onread%}#components-with-onread-event). This method was implemented to be [used together with the `OnRead` event]({%slug common-features-data-binding-onread%}#refresh-data), but it works with `Data` too. Future UI for Blazor versions will expose the `Rebind()` method for all databound components.
-* Reset the `Data` parameter reference. In some specific scenarios, you may also need to call `StateHasChanged()`.
+* Reset the `Data` parameter reference. Sometimes, you may also need to call `StateHasChanged()` - for example, if the refreshing occurs in `OnAfterRenderAsync`.
 
 The [example below](#example) demonstrates the second and third option.
 

--- a/components/autocomplete/events.md
+++ b/components/autocomplete/events.md
@@ -112,7 +112,7 @@ from model: @Role
 
 ## OnRead
 
-You can use the he `OnRead` event to provide data to the component according to some custom logic and according to the current user input and/or scroll position (for [virtualization]({%slug autocomplete-virtualization%})). The event fires when:
+You can use the he [`OnRead` event]({%slug common-features-data-binding-onread%}) to provide data to the component according to some custom logic and according to the current user input and/or scroll position (for [virtualization]({%slug autocomplete-virtualization%})). The event fires when:
 
 * the component initializes
 * the user [filters]({%slug autocomplete-filter%})

--- a/components/combobox/events.md
+++ b/components/combobox/events.md
@@ -204,7 +204,7 @@ See the [ComboBox Overview - Selected Item]({%slug components/combobox/overview%
 
 ## OnRead
 
-You can use the `OnRead` event to provide data to the component according to some custom logic and according to the current user input and/or scroll position (for [virtualization]({%slug combobox-virtualization%})). The event fires when:
+You can use the [`OnRead` event]({%slug common-features-data-binding-onread%}) to provide data to the component according to some custom logic and according to the current user input and/or scroll position (for [virtualization]({%slug combobox-virtualization%})). The event fires when:
 
 * the component initializes
 * the user [filters]({%slug components/combobox/filter%})

--- a/components/dropdownlist/events.md
+++ b/components/dropdownlist/events.md
@@ -115,7 +115,7 @@ from model: @MyItem
 
 ## OnRead
 
-You can use the `OnRead` event to provide data to the component according to some custom logic and according to the current user input and/or scroll position (for [virtualization]({%slug dropdownlist-virtualization%})). The event fires when:
+You can use the [`OnRead` event]({%slug common-features-data-binding-onread%}) to provide data to the component according to some custom logic and according to the current user input and/or scroll position (for [virtualization]({%slug dropdownlist-virtualization%})). The event fires when:
 
 * the component initializes
 * the user [filters]({%slug components/dropdownlist/filter%})

--- a/components/grid/manual-operations.md
+++ b/components/grid/manual-operations.md
@@ -14,7 +14,7 @@ By default, the grid will receive the entire collection of data, and it will per
 
 >tip This article describes how you can load data on demand and implement filtering, paging, sorting on the server.
 >
-> Detailed examples showcase the functionality of the `OnRead` event that you need to use.
+> Detailed examples showcase the functionality of the [`OnRead` event]({%slug common-features-data-binding-onread%}) that you need to use.
 >
 > You can also find runnable sample apps in the [Serialize the DataSoureRequest to the server](https://github.com/telerik/blazor-ui/tree/master/grid/datasourcerequest-on-server) repo.
 

--- a/components/listview/events.md
+++ b/components/listview/events.md
@@ -29,7 +29,7 @@ You can read more about the CUD events in the [ListView Editing]({%slug listview
 
 ## Read Event
 
-In the common case, you provide all the data to the listview's Data collection and the listview performs paging on it for you. In some cases you may want to do this with your own code (for example, to retrieve only a small number of items in order to improve the backend performance). You can do this by attaching to the `OnRead` event where you can perform all the data read operations in the listview. You can read more about it in the [Manual Data Source Operations]({%slug listview-manual-operations%}) article.
+In the common case, you provide all the data to the listview's Data collection and the listview performs paging on it for you. In some cases you may want to do this with your own code (for example, to retrieve only a small number of items in order to improve the backend performance). You can do this by attaching to the [`OnRead` event]({%slug common-features-data-binding-onread%}) where you can perform all the data read operations in the listview. You can read more about it in the [Manual Data Source Operations]({%slug listview-manual-operations%}) article.
 
 ### OnModelInit
 

--- a/components/listview/manual-operations.md
+++ b/components/listview/manual-operations.md
@@ -10,7 +10,7 @@ position: 5
 
 # Manual Data Source Operations
 
-The ListView lets you fetch the current page of data on demand through the `OnRead` event. This can let you optimize database queries and return only a small number of records.
+The ListView lets you fetch the current page of data on demand through the [`OnRead` event]({%slug common-features-data-binding-onread%}). This can let you optimize database queries and return only a small number of records.
 
 In this article you will find examples how to:
 * implement [custom paging](#custom-paging)

--- a/components/multiselect/events.md
+++ b/components/multiselect/events.md
@@ -122,7 +122,7 @@ from the model:
 
 ## OnRead
 
-You can use the he `OnRead` event to provide data to the component according to some custom logic and according to the current user input and/or scroll position (for [virtualization]({%slug multiselect-virtualization%})). The event fires when:
+You can use the he [`OnRead` event]({%slug common-features-data-binding-onread%}) to provide data to the component according to some custom logic and according to the current user input and/or scroll position (for [virtualization]({%slug multiselect-virtualization%})). The event fires when:
 
 * the component initializes
 * the user [filters]({%slug multiselect-filter%})


### PR DESCRIPTION
This PR includes 2 new common data binding articles - one for Overview + `Data` and one for `OnRead`.

I also included some links to these new articles on other Getting Started pages and data-binding-related articles.

In a next iteration, I will polish the data binding articles of all components to integrate better with these new pages.