### PR TITLE
Blazor-Docs: Fix typo in components/combobox/refresh-data.md

### DIFF
--- a/components/combobox/refresh-data.md
+++ b/components/combobox/refresh-data.md
@@ -21,7 +21,7 @@ In this article:
 
 ## Rebind Method
 
-To refresh the AutoComplete data when using [`OnRead`]({%slug components/combobox/events%}#onread), call the `Rebind` method of the TelerikAutoComplete reference. This will fire the `OnRead` event and execute the business logic in the handler.
+To refresh the ComboBox data when using [`OnRead`]({%slug components/combobox/events%}#onread), call the `Rebind` method of the TelerikComboBox reference. This will fire the `OnRead` event and execute the business logic in the handler.
 
 ````CSHTML
 @* Clicking on the Rebind button will delete the first option from the dropdown and refresh the data *@


### PR DESCRIPTION
The cause of this error is most likely copy-pasting from https://docs.telerik.com/blazor-ui/components/autocomplete/refresh-data#rebind-method.