### PR TITLE
Missing property in hardcoded data generation

### DIFF
--- a/components/filemanager/data-binding/hierarchical-data.md
+++ b/components/filemanager/data-binding/hierarchical-data.md
@@ -77,6 +77,7 @@ This approach of providing items lets you gather separate collections of data th
                 MyModelId = "1",
                 Name = "Work Files",
                 IsDirectory = true,
+                HasDirectories = true,
                 DateCreated = new DateTime(2022, 1, 2),
                 DateCreatedUtc = new DateTime(2022, 1, 2),
                 DateModified = new DateTime(2022, 2, 3),


### PR DESCRIPTION
The root directory needs the 'HasDirectories' property set to true for the component to display the child directories.
