### PR TITLE
Including [FromForm] in the Remove signature

### DIFF
--- a/components/upload/overview.md
+++ b/components/upload/overview.md
@@ -116,7 +116,7 @@ namespace MyBlazorApp.Controllers
         }
 
         [HttpPost]
-        public ActionResult Remove(string files) // must match RemoveField
+        public ActionResult Remove([FromForm] string files) // must match RemoveField
         {
             if (files != null)
             {


### PR DESCRIPTION
After following the controller example and some debugging I had to add [FromForm] to the Remove signature before the upload would hit the controller action.

CLA Form below has been signed/submitted.

Note to external contributors: make sure to sign our Contribution License Agreement (CLA) for Blazor UI first:

https://forms.office.com/Pages/ResponsePage.aspx?id=Z2om2-DLJk2uGtBYH-A1NbWxVqugKN5DvVp8I-1AgOBURFBVSkwyMlA1TkFDVFdMNU1aM1o1UlZQOC4u
