### PR TITLE
docs(editor): Revamp tools and commands

### DIFF
--- a/components/editor/built-in-tools.md
+++ b/components/editor/built-in-tools.md
@@ -18,7 +18,7 @@ This article explains which are the built-in tools and commands of the Editor, h
 
 This article describes the Editor *tools* and *commands*.
 
-An Editor *tool* is the visible interface for a given action. For example, the button that bolds text is a tool. Built-in  tools can render as buttons, color pickers or dropdown lists. The Editor supports custom tools with custom rendering.
+An Editor *tool* is the visible interface for a given action. For example, the button that bolds text is a tool. Built-in  tools can render as buttons, color pickers or dropdown lists. The Editor also supports [custom tools with custom rendering]({%slug editor-custom-tools%}).
 
 An Editor *command* is the action, which modifies the HTML value in some way. Each built-in Editor tool has an associated command. Custom tools can execute business logic or invoke built-in commands.
 

--- a/components/editor/built-in-tools.md
+++ b/components/editor/built-in-tools.md
@@ -28,7 +28,7 @@ The information about the Editor tools and commands is organized in tables below
 
 * `Command Name` - use it to [execute the command programmatically](#programmatic-execution). In this case, also use the syntax from the `Argument` column.
 
-* `Tool Type` - a tool can be a button, a dropdown list or a color picker. Only buttons can be added to tool groups in the [toolbar]({%slug editor-toolbars%}).
+* `Tool Type` - a tool can be a [button](/blazor-ui/api/Telerik.Blazor.Components.Editor.ButtonTool), a [dropdown list](/blazor-ui/api/Telerik.Blazor.Components.Editor.DropDownListTool) or a [color picker](/blazor-ui/api/Telerik.Blazor.Components.Editor.ColorTool). Each of these three types exposes some customization options. See the examples for the [color tools](#color-tool-customization), [font tools](#font-tool-customization) and the [Format tool](#format-tool-customization). Only *buttons* can be added to tool groups in the [toolbar]({%slug editor-toolbars%}).
 
 * `Description` - information about what the tool and command do.
 
@@ -74,7 +74,9 @@ Here is a simple example that demonstrates how to use class names, command names
 
 * [Inline Tools](#inline-tools)
     * [Color Tool Customization](#color-tool-customization)
+    * [Font Tool Customization](#font-tool-customization)
 * [Block Tools](#block-tools)
+    * [Format Tool Customization](#format-tool-customization)
 * [Table Tools](#table-tools)
 * [Commands Without Built-in Tools](#commands-without-built-in-tools)
 * [Programmatic Command Execution](#programmatic-execution)
@@ -128,14 +130,14 @@ The inline tools add or work with inline HTML elements. For example, such elemen
             <td>new LinkCommandArgs(string href, string text, string target, string title, null)</td>
         </tr>
         <tr>
-            <td>FontFamily</td>
+            <td><a href="#font-tool-customization">FontFamily</a></td>
             <td>fontFamily</td>
             <td>dropdown</td>
             <td>Sets the font typeface</td>
             <td>new FormatCommandArgs(string commandName, string Value)</td>
         </tr>
         <tr>
-            <td>FontSize</td>
+            <td><a href="#font-tool-customization">FontSize</a></td>
             <td>fontSize</td>
             <td>dropdown</td>
             <td>Sets the text font size</td>
@@ -189,20 +191,70 @@ The inline tools add or work with inline HTML elements. For example, such elemen
 
 ### Color Tool Customization
 
-The `ForeColor` and `BackgroundColor` tools expose a `Colors` property that accepts a color collection as `IEnumerable<string>`. You can provide a member of [`ColorPalettePresets`](https://docs.telerik.com/blazor-ui/api/Telerik.Blazor.ColorPalettePresets), or a custom list of [RGB(A) or HEX colors in different supported formats]({%slug colorpicker-overview%}#supported-value-formats).
+The `ForeColor` and `BackgroundColor` tools expose a `Colors` property that accepts a color collection as `IEnumerable<string>`. You can provide a member of [`ColorPalettePresets`](/blazor-ui/api/Telerik.Blazor.ColorPalettePresets), or a custom list of [RGB(A) or HEX colors in different supported formats]({%slug colorpicker-overview%}#supported-value-formats). It is also possible to change the tooltips via `Title`.
 
 ````CSHTML
 @using Telerik.Blazor.Components.Editor
 
-<TelerikEditor Tools="@Tools"
-               @bind-Value="@Value"></TelerikEditor>
+<TelerikEditor Tools="@EditorTools"
+               @bind-Value="@EditorValue">
+</TelerikEditor>
 
 @code {
-    string Value { get; set; }
+    private string EditorValue { get; set; }
 
-    List<IEditorTool> Tools { get; set; } = new List<IEditorTool>() {
-        new ForeColor() { Colors = new List<string> { "#f00", "#ff9900", "rgb(0, 128, 0)", "rgba(0, 0, 255, .8)" } },
-        new BackgroundColor() { Colors = ColorPalettePresets.Basic }
+    private List<IEditorTool> EditorTools { get; set; } = new List<IEditorTool>()
+    {
+        new ForeColor()
+        {
+            Title = "Text Color",
+            Colors = new List<string> { "#f00", "#ff9900", "rgb(0, 128, 0)", "rgba(0, 0, 255, .8)" }
+        },
+        new BackgroundColor()
+        {
+            Title = "Background Color",
+            Colors = ColorPalettePresets.Basic
+        }
+    };
+}
+````
+
+
+### Font Tool Customization
+
+The [`FontFamily`](/blazor-ui/api/Telerik.Blazor.Components.Editor.FontFamily) and [`FontSize`](/blazor-ui/api/Telerik.Blazor.Components.Editor.FontSize) tools have a `Data` property that accepts a `List<EditorDropDownListItem>`. Use it to customize the available options in these dropdowns. You can also change the dropdown label via `DefaultText`.
+
+````CSHTML
+@using Telerik.Blazor.Components.Editor
+
+<TelerikEditor @bind-Value="@EditorValue"
+               Tools="@EditorTools">
+</TelerikEditor>
+
+@code {
+    private string EditorValue { get; set; }
+
+    private List<IEditorTool> EditorTools { get; set; } = new List<IEditorTool>()
+    {
+        new FontFamily()
+        {
+            DefaultText = "Font Family",
+            Data = new List<EditorDropDownListItem>()
+            {
+                new EditorDropDownListItem("Georgia", "georgia"),
+                new EditorDropDownListItem("Lucida Console", "'lucida console'")
+            }
+        },
+        new FontSize()
+        {
+            DefaultText = "Text Size",
+            Data = new List<EditorDropDownListItem>()
+            {
+                new EditorDropDownListItem("Small", "12px"),
+                new EditorDropDownListItem("Medium", "16px"),
+                new EditorDropDownListItem("Large", "24px")
+            }
+        }
     };
 }
 ````
@@ -253,7 +305,7 @@ All tools in the table below are *buttons*, except `Format`, which is a *dropdow
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
-            <td>Format</td>
+            <td><a href="#format-tool-customization">Format</a></td>
             <td>format</td>
             <td>Applies standard formatting to the selected text like Heading 1, Paragraph and so on. Unlike the other tools in this table, this one is a dropdown.</td>
             <td>new FormatCommandArgs(string commandName, string Value)</td>
@@ -308,6 +360,34 @@ All tools in the table below are *buttons*, except `Format`, which is a *dropdow
         </tr>
     </tbody>
 </table>
+
+### Format Tool Customization
+
+The [`Format` tool exposes a `Data` property](/blazor-ui/api/Telerik.Blazor.Components.Editor.Format) that accepts a `List<EditorDropDownListItem>`. Use it to reduce or reorder the items in the dropdown list.
+
+````CSHTML
+@using Telerik.Blazor.Components.Editor
+
+<TelerikEditor @bind-Value="@EditorValue"
+               Tools="@EditorTools">
+</TelerikEditor>
+
+@code {
+    private string EditorValue { get; set; }
+
+    private List<IEditorTool> EditorTools { get; set; } = new List<IEditorTool>()
+    {
+        new Format()
+        {
+            Data = new List<EditorDropDownListItem>()
+            {
+                new EditorDropDownListItem("Paragraph", "p"),
+                new EditorDropDownListItem("Heading 1", "h1")
+            }
+        }
+    };
+}
+````
 
 
 ## Table Tools

--- a/components/editor/built-in-tools.md
+++ b/components/editor/built-in-tools.md
@@ -43,28 +43,28 @@ Here is a simple example that demonstrates how to use class names, command names
 
 <TelerikButton OnClick="@InsertParagraph">Insert Paragraph in the Editor</TelerikButton>
 
-<TelerikEditor @ref="Editor"
+<TelerikEditor @ref="EditorRef"
                Tools="@EditorTools"
-               @bind-Value="@Value">
+               @bind-Value="@EditorValue">
 </TelerikEditor>
 
 @code {
-    public TelerikEditor Editor { get; set; }
+    private TelerikEditor EditorRef { get; set; }
+
+    private string EditorValue { get; set; } = @"<p>foo</p><p>bar</p>";
 
     // "Bold", "Italic" and "Underline" are class names
-    public List<IEditorTool> EditorTools { get; set; } = new List<IEditorTool>() {
+    private List<IEditorTool> EditorTools { get; set; } = new List<IEditorTool>() {
         new Bold(),
         new Italic(),
         new Underline()
     };
 
-    public string Value { get; set; } = @"<p>foo</p><p>bar</p>";
-
     private async Task InsertParagraph()
     {
         // "insertHtml" is a command name
         // HtmlCommandArgs is the ExecuteAsync argument
-        await Editor.ExecuteAsync(new HtmlCommandArgs("insertHtml", $"<p>baz {DateTime.Now.Millisecond}</p>"));
+        await EditorRef.ExecuteAsync(new HtmlCommandArgs("insertHtml", $"<p>baz {DateTime.Now.Millisecond}</p>"));
     }
 }
 ````

--- a/components/editor/built-in-tools.md
+++ b/components/editor/built-in-tools.md
@@ -210,7 +210,7 @@ The `ForeColor` and `BackgroundColor` tools expose a `Colors` property that acce
 
 ## Block Tools
 
-The `Block` tools add or work with block HTML elements, like `<h1>`, `<h2>`, `<p>` and `<ul>`.
+The block tools add or work with block HTML elements, like `<h1>`, `<h2>`, `<p>` and `<ul>`.
 
 All tools in the table below are *buttons*, except `Format`, which is a *dropdown*.
 

--- a/components/editor/built-in-tools.md
+++ b/components/editor/built-in-tools.md
@@ -11,158 +11,181 @@ position: 40
 
 # Editor Built-in Tools
 
-This article explains which are the built-in tools and commands of the `Editor`, how to invoke them programatically and what functionality they offer. 
-
-In this article:
-
-* [Built-in Tools and Commands](#built-in-tools)
-	* [Inline Tools](#inline-tools)
-	* [Color Tool Customization](#color-tool-customization)
-	* [Block Tools](#block-tools)
-	* [Table Tools](#table-tools)
-	* [Commands Without Built-in Tools](#commands-without-built-in-tools)
-* [Programmatic Execution](#programmatic-execution)
+This article explains which are the built-in tools and commands of the Editor, how to invoke them programmatically and what functionality they offer.
 
 
-## Built-in Tools
+## How to Use this Article
 
-The sections below list the tools that come with the editor and provide the following information:
+This article describes the Editor *tools* and *commands*.
 
-* `Tool Name` - the human-readable name of the tool.
+An Editor *tool* is the visible interface for a given action. For example, the button that bolds text is a tool. Built-in  tools can render as buttons, color pickers or dropdown lists. The Editor supports custom tools with custom rendering.
 
-* `Command Name` - the `commandName` of the tool for [executing it programmatically](#programmatic-execution).
+An Editor *command* is the action, which modifies the HTML value in some way. Each built-in Editor tool has an associated command. Custom tools can execute business logic or invoke built-in commands.
 
-* `Tool Type` - the type of the tool - whether it is a button, a dropdown or a color tool. Only buttons can be added to tool groups in the [toolbar]({%slug editor-toolbars%}).
+The information about the Editor tools and commands is organized in tables below. Here is what the table headers mean:
 
-* `Description` - more detailed information on what the tool does.
+* `Class Name` - use it to [add the tool to the Editor toolbar]({%slug editor-toolbars%})
 
-* `Class Name` - the name of the class that you need to instantiate in order to [add the tool to the toolbar]({%slug editor-toolbars%}) in your own code.
+* `Command Name` - use it to [execute the command programmatically](#programmatic-execution). In this case, also use the syntax from the `Argument` column.
 
-* `Arguments` - the type of the argument you must pass to the `ExecuteAsync` method of the editor in order to invoke the command programmatically.
+* `Tool Type` - a tool can be a button, a dropdown list or a color picker. Only buttons can be added to tool groups in the [toolbar]({%slug editor-toolbars%}).
 
-There are the following types of tools:
+* `Description` - information about what the tool and command do.
+
+* `Argument for ExecuteAsync` - shows the expected class instance and parameters that you must pass to the Editor's `ExecuteAsync` method to invoke the command programmatically.
+
+Here is a simple example that demonstrates how to use class names, command names and `ExecuteAsync` arguments.
+
+>caption Use tool class names and command names with the Blazor Editor
+
+````CSHTML
+@using Telerik.Blazor.Components.Editor
+
+<TelerikButton OnClick="@InsertParagraph">Insert Paragraph in the Editor</TelerikButton>
+
+<TelerikEditor @ref="Editor"
+               Tools="@EditorTools"
+               @bind-Value="@Value">
+</TelerikEditor>
+
+@code {
+    public TelerikEditor Editor { get; set; }
+
+    // "Bold", "Italic" and "Underline" are class names
+    public List<IEditorTool> EditorTools { get; set; } = new List<IEditorTool>() {
+        new Bold(),
+        new Italic(),
+        new Underline()
+    };
+
+    public string Value { get; set; } = @"<p>foo</p><p>bar</p>";
+
+    private async Task InsertParagraph()
+    {
+        // "insertHtml" is a command name
+        // HtmlCommandArgs is the ExecuteAsync argument
+        await Editor.ExecuteAsync(new HtmlCommandArgs("insertHtml", $"<p>baz {DateTime.Now.Millisecond}</p>"));
+    }
+}
+````
+
+
+## Built-in Tools and Commands
 
 * [Inline Tools](#inline-tools)
+    * [Color Tool Customization](#color-tool-customization)
 * [Block Tools](#block-tools)
 * [Table Tools](#table-tools)
 * [Commands Without Built-in Tools](#commands-without-built-in-tools)
+* [Programmatic Command Execution](#programmatic-execution)
 
-### Inline Tools
 
-The `Inline` tools work with or add an inline HTML element. Example of these are an `<a>`, `<img>`, `<strong>` and `<em>`.
+## Inline Tools
 
->caption Table 1: Inline tools in the Editor
+The inline tools add or work with inline HTML elements. For example, such elements are `<a>`, `<img>`, `<strong>` and `<em>`.
+
+>caption Table 1: Inline Tools of the Editor
+
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 <table>
     <thead>
         <tr>
-            <th>Tool Name</th>
+            <th>Class Name</th>
             <th>Command Name</th>
             <th>Tool Type</th>
             <th>Description</th>
-            <th>Class Name</th>
-            <th>Arguments</th>
+            <th>Argument for ExecuteAsync</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td>Bold</td>
             <td>bold</td>
-            <td>Button</td>
-            <td>Applies bold formatting to the selected text</td>
-            <td>new Bold()</td>
+            <td>button</td>
+            <td>Applies bold style</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
             <td><a href="#color-tool-customization">BackgroundColor</a></td>
             <td>backColor</td>
-            <td>Color</td>
-            <td>Change the background color of the selected text</td>
-            <td>new BackgroundColor()</td>
+            <td>color</td>
+            <td>Changes the background color</td>
             <td>new FormatCommandArgs(string commandName, string Value)</td>
         </tr>
         <tr>
             <td><a href="#color-tool-customization">ForeColor</a></td>
             <td>foreColor</td>
-            <td>Color</td>
-            <td>Change the font color of a selected text</td>
-            <td>new ForeColor()</td>
+            <td>color</td>
+            <td>Changes the text color</td>
             <td>new FormatCommandArgs(string commandName, string Value)</td>
         </tr>
         <tr>
             <td>CreateLink</td>
             <td>createLink</td>
-            <td>Button</td>
-            <td>Create a hyperlink from the selected text</td>
-            <td>new CreateLink()</td>
+            <td>button</td>
+            <td>Creates a hyperlink</td>
             <td>new LinkCommandArgs(string href, string text, string target, string title, null)</td>
         </tr>
         <tr>
             <td>FontFamily</td>
             <td>fontFamily</td>
-            <td>DropDown</td>
-            <td>Specify the font typeface for the selected text</td>
-            <td>new FontFamily()</td>
+            <td>dropdown</td>
+            <td>Sets the font typeface</td>
             <td>new FormatCommandArgs(string commandName, string Value)</td>
         </tr>
         <tr>
             <td>FontSize</td>
             <td>fontSize</td>
-            <td>DropDown</td>
-            <td>Specify the size of the selected text</td>
-            <td>new FontSize()</td>
+            <td>dropdown</td>
+            <td>Sets the text font size</td>
             <td>new FormatCommandArgs(string commandName, string Value)</td>
         </tr>
         <tr>
             <td>Italic</td>
             <td>italic</td>
-            <td>Button</td>
-            <td>Applies italic formatting to the selected text</td>
-            <td>new Italic()</td>
+            <td>button</td>
+            <td>Applies italic style</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
             <td>Strikethrough</td>
             <td>strikethrough</td>
-            <td>Button</td>
-            <td>Applies strikethrough formatting to the selected text</td>
-            <td>new Strikethrough()</td>
+            <td>button</td>
+            <td>Applies strikethrough formatting</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
             <td>SubScript</td>
             <td>subscript</td>
-            <td>Button</td>
+            <td>button</td>
             <td>Makes the selected text subscript</td>
-            <td>new SubScript()</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
             <td>SuperScript</td>
             <td>superscript</td>
-            <td>Button</td>
+            <td>button</td>
             <td>Makes the selected text superscript</td>
-            <td>new SuperScript</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
             <td>Underline</td>
             <td>underline</td>
-            <td>Button</td>
-            <td>Applies underline formatting to the selected text</td>
-            <td>new Underline()</td>
+            <td>button</td>
+            <td>Applies underline style</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
             <td>Unlink</td>
             <td>unlink</td>
-            <td>Button</td>
-            <td>Remove a hyperlink</td>
-            <td>new Unlink()</td>
+            <td>button</td>
+            <td>Removes a hyperlink</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
     </tbody>
 </table>
+
 
 ### Color Tool Customization
 
@@ -184,278 +207,233 @@ The `ForeColor` and `BackgroundColor` tools expose a `Colors` property that acce
 }
 ````
 
-### Block Tools
 
-The `Block` tools work with or add a block HTML element, like `<h1>`, `<h2>`, `<p>` and `<ul>`.
+## Block Tools
 
->caption Table 2: Block tools in the Editor
+The `Block` tools add or work with block HTML elements, like `<h1>`, `<h2>`, `<p>` and `<ul>`.
+
+All tools in the table below are *buttons*, except `Format`, which is a *dropdown*.
+
+>caption Table 2: Block Tools of the Editor
+
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 <table>
     <thead>
         <tr>
-            <th>Tool Name</th>
-            <th>Command Name</th>
-            <th>Tool Type</th>
-            <th>Description</th>
             <th>Class Name</th>
-            <th>Arguments</th>
+            <th>Command Name</th>
+            <th>Description</th>
+            <th>Argument for ExecuteAsync</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td>AlignCenter</td>
             <td>alignCenter</td>
-            <td>Button</td>
             <td>Aligns the selected paragraph to the center</td>
-            <td>new AlignCenter()</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
             <td>AlignJustify</td>
             <td>alignJustify</td>
-            <td>Button</td>
             <td>Justifies the selected paragraph</td>
-            <td>new AlignJustify()</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
             <td>AlignLeft</td>
             <td>alignLeft</td>
-            <td>Button</td>
             <td>Aligns the selected paragraph to the left</td>
-            <td>new AlignLeft()</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
             <td>AlignRight</td>
             <td>alignRight</td>
-            <td>Button</td>
             <td>Aligns the selected paragraph to the right</td>
-            <td>new AlignRight()</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
             <td>Format</td>
             <td>format</td>
-            <td>DropDown</td>
-            <td>Applies standard formatting to the selected text like Heading 1, Paragraph and so on</td>
-            <td>new Format()</td>
+            <td>Applies standard formatting to the selected text like Heading 1, Paragraph and so on. Unlike the other tools in this table, this one is a dropdown.</td>
             <td>new FormatCommandArgs(string commandName, string Value)</td>
         </tr>
         <tr>
             <td>Indent</td>
             <td>indent</td>
-            <td>Button</td>
-            <td>Add indent to the selected text</td>
-            <td>new Indent()</td>
+            <td>Adds indent to the selected text</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
             <td>InsertImage</td>
             <td>insertImage</td>
-            <td>Button</td>
             <td>Inserts image from a desired URL</td>
-            <td>new InsertImage()</td>
             <td>new ImageCommandArgs(string src, string alt, string width, string height)</td>
         </tr>
         <tr>
             <td>OrderedList</td>
             <td>insertOrderedList</td>
-            <td>Button</td>
-            <td>Creates a list of bullets from the selection</td>
-            <td>new OrderedList()</td>
+            <td>Creates a list of numeric bullets</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
             <td>Outdent</td>
             <td>outdent</td>
-            <td>Button</td>
-            <td>Remove indent from the selected text</td>
-            <td>new Outdent()</td>
+            <td>Removes indent from the selected text</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
             <td>Redo</td>
             <td>redo</td>
-            <td>Button</td>
             <td>Repeats the last undone action</td>
-            <td>new Redo()</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
             <td>ViewHtml</td>
             <td>setHtml</td>
-            <td>Button</td>
-            <td>Offers a HTML view for the selected text</td>
-            <td>new ViewHtml()</td>
+            <td>Shows the raw HTML of the Editor content</td>
             <td>new HtmlCommandArgs(string commandName, string value)</td>
         </tr>
         <tr>
             <td>Undo</td>
             <td>undo</td>
-            <td>Button</td>
-            <td>Undoes the last action</td>
-            <td>new Undo()</td>
+            <td>Reverts the last action</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
             <td>UnorderedList</td>
             <td>insertUnorderedList</td>
-            <td>Button</td>
-            <td>Creates a list of bullets from the selection</td>
-            <td>new UnorderedList()</td>
+            <td>Creates a list of bullets</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
     </tbody>
 </table>
 
-### Table Tools
 
-The `Table` tools add an HTML `<table>` or control its rendering, like adding columns and rows, merging and splitting cells.
+## Table Tools
 
->caption Table 3: Table tools in the Editor
+The table tools create and manipulate HTML `<table>` elements. These tools can add or remove columns and rows, and merge or split cells.
+
+All tools in the table below are *buttons*.
+
+>caption Table 3: Editor Table Tools
+
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 <table>
     <thead>
         <tr>
-            <th>Tool Name</th>
-            <th>Command Name</th>
-            <th>Tool Type</th>
-            <th>Description</th>
             <th>Class Name</th>
-            <th>Arguments</th>
+            <th>Command Name</th>
+            <th>Description</th>
+            <th>Argument for ExecuteAsync</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td>InsertTable</td>
             <td>insertTable</td>
-            <td>Button</td>
             <td>Inserts a table with the desired number of columns and rows</td>
-            <td>new InsertTable()</td>
             <td>new TableCommandArgs(int rows, int cols)</td>
         </tr>
         <tr>
             <td>DeleteTable</td>
             <td>deleteTable</td>
-            <td>Button</td>
             <td>Deletes the selected HTML table</td>
-            <td>new DeleteTable()</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
             <td>AddColumnBefore</td>
             <td>addColumnBefore</td>
-            <td>Button</td>
             <td>Inserts a column before the selected one</td>
-            <td>new AddColumnBefore()</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
             <td>AddColumnAfter</td>
             <td>addColumnAfter</td>
-            <td>Button</td>
             <td>Inserts a column after the selected one</td>
-            <td>new AddColumnAfter()</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
             <td>AddRowBefore</td>
             <td>addRowBefore</td>
-            <td>Button</td>
             <td>Inserts a row before the selected one</td>
-            <td>new AddRowBefore()</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
             <td>AddRowAfter</td>
             <td>addRowAfter</td>
-            <td>Button</td>
             <td>Inserts a row after the selected one</td>
-            <td>new AddRowAfter()</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
             <td>DeleteRow</td>
             <td>deleteRow</td>
-            <td>Button</td>
             <td>Deletes the selected row</td>
-            <td>new DeleteRow()</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
             <td>DeleteColumn</td>
             <td>deleteColumn</td>
-            <td>Button</td>
             <td>Deletes the selected column</td>
-            <td>new DeleteColumn()</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
             <td>MergeCells</td>
             <td>mergeCells</td>
-            <td>Button</td>
             <td>Merges the selected cells</td>
-            <td>new MergeCells()</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
             <td>SplitCell</td>
             <td>splitCell</td>
-            <td>Button</td>
             <td>Splits already merged cells</td>
-            <td>new SplitCell()</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
     </tbody>
 </table>
 
-### Commands Without Built-in Tools
 
-There are commands without built-in tools, but can be [executed programmatically](#programmatic-execution).
+## Commands Without Built-in Tools
 
->caption Table 4: Commands without tools in the Editor
+Some Editor commands have no built-in tools. These commands can only be [invoked programmatically](#programmatic-execution).
+
+>caption Table 4: Editor Commands Without Tools
+
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 <table>
     <thead>
         <tr>
-            <th>Tool Name</th>
             <th>Command Name</th>
-            <th>Tool Type</th>
             <th>Description</th>
-            <th>Class Name</th>
-            <th>Arguments</th>
+            <th>Arguments for ExecuteAsync</th>
         </tr>
     </thead>
     <tbody>
         <tr>
-            <td>Clean Formatting</td>
             <td>cleanFormatting</td>
-            <td>N/A</td>
             <td>Cleans the inline formatting of a selected text</td>
-            <td>N/A</td>
             <td>new ToolCommandArgs(string commandName)</td>
         </tr>
         <tr>
-            <td>Insert HTML</td>
             <td>insertHtml</td>
-            <td>N/A</td>
-            <td>Inserts HTML at the cursor position. To insert multiple nodes, wrap them in a single element.<br />By default this is a block command that will wrap passed inline content in a <code>p</code> or <code>div</code>, depending on the context. To insert inline content, set the third argument to <code>true</code>. There are separate commands for inserting links and images.</td>
-            <td>N/A</td>
+            <td>Inserts HTML at the cursor position. To insert multiple nodes, wrap them in a single element.<br />By default this is a block command that will wrap passed inline content in a <code>p</code> or <code>div</code>, depending on the context. To insert inline content, set the third argument to <code>true</code>.<br />Note there are separate commands for inserting links and images.</td>
             <td>new HtmlCommandArgs(string commandName, string value, bool inline)</td>
         </tr>
     </tbody>
 </table>
 
+
 ## Programmatic Execution
 
-You can invoke the built-in editor tools from outside the component or from [custom tools]({%slug editor-custom-tool%}).
+You can invoke the built-in Editor commands from outside the component or from [custom tools]({%slug editor-custom-tools%}).
 
-In order to do so you need to use the [Editor reference]({%slug editor-overview%}#component-reference) and to call the [ExecuteAsync method]({%slug editor-overview%}#methods).
+In order to do so, you need to use the [Editor reference]({%slug editor-overview%}#component-reference) and to call the [ExecuteAsync method]({%slug editor-overview%}#methods).
 
->tip Use the reference tables above to find the command name and its arguments for the tool you want to invoke.
+>tip Use the reference tables above to find the command name and its arguments for the command you want to invoke.
 
->caption Execute tools from buttons outside the Editor
+>caption Execute commands from buttons outside the Editor
 
 ````CSHTML
 @* Click on the buttons to execute the Editor tools *@
@@ -502,8 +480,8 @@ In order to do so you need to use the [Editor reference]({%slug editor-overview%
 }
 ````
 
+
 ## See Also
 
-  * [Editor Overview]({%slug editor-overview%})
-  * [Editor Toolbar]({%slug editor-toolbars%})
-
+* [Editor Overview]({%slug editor-overview%})
+* [Editor Toolbar]({%slug editor-toolbars%})

--- a/components/editor/custom-tools.md
+++ b/components/editor/custom-tools.md
@@ -1,15 +1,16 @@
 ---
-title: Custom Tool
-page_title: Editor - Custom Tool
-description: How to make a custom Tool in the Editor for Blazor.
-slug: editor-custom-tool
+title: Custom Tools
+page_title: Custom Editor Tools
+description: How to make a custom tool in the Editor for Blazor.
+slug: editor-custom-tools
 tags: telerik,blazor,custom,tool
 published: True
 position: 60
+previous_url: /components/editor/custom-tool
 ---
 
 
-# Editor Custom Tool
+# Editor Custom Tools
 
 The Blazor Editor component lets you add custom tools to its [toolbar]({%slug editor-toolbars%}). In those tools, you can use both the [built-in tools and commands]({%slug editor-built-in-tools%}) the editor provides, and also your own custom logic.
 

--- a/components/editor/overview.md
+++ b/components/editor/overview.md
@@ -57,7 +57,7 @@ The <a href = "https://www.telerik.com/blazor-ui/editor" target="_blank">Blazor 
 
 ## Component Reference
 
-You can use the component reference to call its [Methods](#methods), especially when creating [custom tools]({%slug editor-custom-tool%}). This snippet shows how to obtain a reference and its namespace.
+You can use the component reference to call its [Methods](#methods), especially when creating [custom tools]({%slug editor-custom-tools%}). This snippet shows how to obtain a reference and its namespace.
 
 
 ````CSHTML
@@ -153,7 +153,7 @@ consider - maybe link toolbars, import/export, custom commands, events, validati
 
   * [Toolbar]({%slug editor-toolbars%})
   * [Built-in Tools and Commands]({%slug editor-built-in-tools%})
-  * [Custom Tools]({%slug editor-custom-tool%})
+  * [Custom Tools]({%slug editor-custom-tools%})
   * [Import and Export]({%slug editor-import-export%})
   * [Events]({%slug editor-events%})
   * [Live Demo: Editor](https://demos.telerik.com/blazor-ui/editor/overview)

--- a/components/editor/toolbar.md
+++ b/components/editor/toolbar.md
@@ -11,7 +11,7 @@ position: 20
 
 # Editor Toolbar
 
-The toolbar of the editor is where it command buttons reside and they let the end user apply various formatting and styling - from bold and italic words, to creating lists, tables, inserting images or [custom tools]({%slug editor-custom-tool%}) you can define.
+The toolbar of the editor is where it command buttons reside and they let the end user apply various formatting and styling - from bold and italic words, to creating lists, tables, inserting images or [custom tools]({%slug editor-custom-tools%}) you can define.
 
 ![The Editor Toolbar](images/editor-toolbar-overview.png)
 
@@ -52,7 +52,7 @@ If you do not apply any settings, the `Default` list of tools will be used.
 
 ## Choose Toolbar Items
 
-To define your own customized collection of tools, you use the `Tools` parameter of the Editor component and populate it with the commands you want available. They can include [custom tools]({%slug editor-custom-tool%}).
+To define your own customized collection of tools, you use the `Tools` parameter of the Editor component and populate it with the commands you want available. They can include [custom tools]({%slug editor-custom-tools%}).
 
 The `Tools` collection is a `List<IEditorTool>`.
 

--- a/knowledge-base/editor-get-selection.md
+++ b/knowledge-base/editor-get-selection.md
@@ -45,7 +45,7 @@ At this point, you can apply changes to it with JavaScript.
 If you want to use it on the .NET (Blazor) side, you need to:
 
 1. Serialize the selection to a string so .NET can understand it, by using the `toString()` method.
-1. Call a JavaScript function from a [Custom Tool]({%slug editor-custom-tool%}) in the Editor that will return that selection.
+1. Call a JavaScript function from a [Custom Tool]({%slug editor-custom-tools%}) in the Editor that will return that selection.
 
 <div class="skip-repl"></div>
 ````Component
@@ -104,7 +104,7 @@ At this point, you can apply changes to it with JavaScript.
 If you want to use it on the .NET (Blazor) side, you need to:
 
 1. Serialize the selection to a string so .NET can understand it, by using the `toString()` method.
-1. Call a JavaScript function from a [Custom Tool]({%slug editor-custom-tool%}) in the Editor that will return that selection.
+1. Call a JavaScript function from a [Custom Tool]({%slug editor-custom-tools%}) in the Editor that will return that selection.
 
 <div class="skip-repl"></div>
 ````Component


### PR DESCRIPTION
* Switched the table layout to auto.
* Optimized the table columns.
* Added some examples to make the "raw" documentation easier to understand.