### PR TITLE
docs: Use a single template for table layout per page

### DIFF
--- a/_contentTemplates/common/parameters-table-styles.md
+++ b/_contentTemplates/common/parameters-table-styles.md
@@ -1,6 +1,6 @@
 #table-layout
 <style>
-    article style + table {
+    article table {
         table-layout: auto;
         word-break: normal;
     }

--- a/common-features/data-binding/onread.md
+++ b/common-features/data-binding/onread.md
@@ -70,12 +70,7 @@ The `OnRead` event handler receives an argument, which inherits from [`ReadEvent
 
 The following properties of the event argument object are common for all [components with an `OnRead` event](#components-with-onread-event). Other properties are discussed in component-specific articles.
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Property | Type | Description |
 | --- | --- | --- |
@@ -112,12 +107,7 @@ The `ToDataSourceResult` extension method is able to extract the requested data 
 
 `ToDataSourceResult` returns a [`DataSourceResult` object](/blazor-ui/api/Telerik.DataSource.DataSourceResult). Its most important properties are:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Property | Type | Description |
 | --- | --- | --- |

--- a/common-features/data-binding/onread.md
+++ b/common-features/data-binding/onread.md
@@ -107,8 +107,6 @@ The `ToDataSourceResult` extension method is able to extract the requested data 
 
 `ToDataSourceResult` returns a [`DataSourceResult` object](/blazor-ui/api/Telerik.DataSource.DataSourceResult). Its most important properties are:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Property | Type | Description |
 | --- | --- | --- |
 | `Data` | `IEnumerable` | The chunk (page) of data items to render. All data operations are already applied (sorting, filtering, etc.) |

--- a/components/autocomplete/events.md
+++ b/components/autocomplete/events.md
@@ -268,8 +268,6 @@ The `OnClose` event fires before the AutoComplete popup closes.
 
 The event handler receives as an argument an `AutoCompleteCloseEventArgs` object that contains:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Property | Description |
 | --- | --- |
 | `IsCancelled` | Set the `IsCancelled` property to `true` to cancel the closing of the popup. |
@@ -304,8 +302,6 @@ The event handler receives as an argument an `AutoCompleteCloseEventArgs` object
 The `OnItemRender` event fires when each item in the AutoComplete dropdown renders.
 
 The event handler receives as an argument an `AutoCompleteItemRenderEventArgs<TItem>` object that contains:
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Property | Description |
 | --- | --- |

--- a/components/autocomplete/overview.md
+++ b/components/autocomplete/overview.md
@@ -72,12 +72,7 @@ The Blazor AutoComplete @[template](/_contentTemplates/dropdowns/features.md#gro
 
 The Blazor AutoComplete provides various parameters that allow you to configure the component:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Parameter    | Type  | Description |
 | ----------- | ----------- | -------|

--- a/components/card/overview.md
+++ b/components/card/overview.md
@@ -58,12 +58,8 @@ The below snippet demonstrates the setup of a Card component with all building b
 
 The Card provides various parameters that allow you to configure the component:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Parameter   | Type | Description |
 | ----------- | ----------- | -------|
 | `Width` | `string` | defines width of the component.

--- a/components/carousel/overview.md
+++ b/components/carousel/overview.md
@@ -91,8 +91,6 @@ The Carousel is a generic component. Its type depends on the type of its model a
 
 The table below lists the Carousel methods. Also consult the [Carousel API](/blazor-ui/api/Telerik.Blazor.Components.TelerikCarousel-1).
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Method | Description |
 | --- | --- |
 | `Rebind` | [Refreshes the component data]({%slug carousel-refresh-data%}#rebind-method). |

--- a/components/chart/overview.md
+++ b/components/chart/overview.md
@@ -145,8 +145,6 @@ The following table lists Chart parameters, which are not discussed elsewhere in
 
 To execute Chart methods, obtain reference to the component instance via `@ref`.
 
- @[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Method  | Description |
 |---------|-------------|
 | Refresh | Use the method to programmatically re-render the Chart.  |

--- a/components/checkbox/appearance.md
+++ b/components/checkbox/appearance.md
@@ -57,8 +57,6 @@ You can increase or decrease the size of the CheckBox by setting the `Size` attr
 
 The `Rounded` attribute applies the `border-radius` CSS rule to the checkbox to achieve curving of the edges. You can set it to a member of the `Telerik.Blazor.ThemeConstants.CheckBox.Rounded` class:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Class member | Manual declaration |
 |------------|--------|
 |`Small` |`sm`|

--- a/components/checkbox/appearance.md
+++ b/components/checkbox/appearance.md
@@ -20,12 +20,8 @@ You can control the appearance of the CheckBox button by setting the following a
 
 You can increase or decrease the size of the CheckBox by setting the `Size` attribute to a member of the `Telerik.Blazor.ThemeConstants.CheckBox.Size` class:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Class member | Manual declaration |
 |------------|--------|
 |`Small` |`sm`|
@@ -61,12 +57,8 @@ You can increase or decrease the size of the CheckBox by setting the `Size` attr
 
 The `Rounded` attribute applies the `border-radius` CSS rule to the checkbox to achieve curving of the edges. You can set it to a member of the `Telerik.Blazor.ThemeConstants.CheckBox.Rounded` class:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Class member | Manual declaration |
 |------------|--------|
 |`Small` |`sm`|

--- a/components/checkbox/overview.md
+++ b/components/checkbox/overview.md
@@ -49,12 +49,8 @@ The Blazor Checkbox fires value change, focus and state change events that you c
 
 The Blazor CheckBox provides various parameters that allow you to configure the component:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Parameter | Type | Description |
 | ----------- | ----------- | ----------- |
 | `Class` | `string` | Renders a custom CSS class to the `<input class="k-checkbox">` element. |

--- a/components/colorpalette/overview.md
+++ b/components/colorpalette/overview.md
@@ -47,12 +47,8 @@ The Blazor ColorPalette fires value change and blur events that you can handle a
 
 The Blazor ColorPalette provides various parameters to configure the component. Also check the [ColorPalette public API](/blazor-ui/api/Telerik.Blazor.Components.TelerikColorPalette).
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Parameter | Type and Default Value | Description |
 | --- | --- | --- |
 | `Class` | `string` | Renders a custom CSS class to the `<div class="k-colorpalette">` element. |

--- a/components/colorpicker/events.md
+++ b/components/colorpicker/events.md
@@ -123,8 +123,6 @@ The `OnClose` event fires before the ColorPicker popup closes.
 
 The event handler receives as an argument an `MultiColumnComboBoxCloseEventArgs` object that contains:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Property | Description |
 | --- | --- |
 | `IsCancelled` | Set the `IsCancelled` property to `true` to cancel the closing of the popup. |

--- a/components/combobox/events.md
+++ b/components/combobox/events.md
@@ -310,8 +310,6 @@ The `OnOpen` event fires before the ComboBox popup renders.
 
 The event handler receives as an argument an `ComboBoxOpenEventArgs` object that contains:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Property | Description |
 | --- | --- |
 | `IsCancelled` | Set the `IsCancelled` property to `true` to cancel the opening of the popup. |
@@ -352,8 +350,6 @@ The event handler receives as an argument an `ComboBoxOpenEventArgs` object that
 The `OnClose` event fires before the ComboBox popup closes.
 
 The event handler receives as an argument an `ComboBoxCloseEventArgs` object that contains:
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Property | Description |
 | --- | --- |
@@ -400,8 +396,6 @@ The event handler receives as an argument an `ComboBoxCloseEventArgs` object tha
 The `OnItemRender` event fires when each item in the ComboBox dropdown renders.
 
 The event handler receives as an argument an `ComboBoxItemRenderEventArgs<TItem>` object that contains:
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Property | Description |
 | --- | --- |

--- a/components/combobox/overview.md
+++ b/components/combobox/overview.md
@@ -74,12 +74,8 @@ The Blazor ComboBox @[template](/_contentTemplates/dropdowns/features.md#groupin
 
 >caption The ComboBox provides various parameters that allow you to configure the component:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Parameter      | Type | Description
 | ----------- | ----------- | -----------|
 | `AllowCustom` | `bool` | whether the user can enter [custom values]({%slug components/combobox/custom-value%}). If enabled, the `ValueField` must be a `string`.

--- a/components/dateinput/overview.md
+++ b/components/dateinput/overview.md
@@ -67,8 +67,6 @@ You can ensure that the component value is acceptable by using the built-in vali
 
 The following parameters enable you to customize the appearance of the Blazor DateInput:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Attribute | Type and Default Value | Description |
 |----------|----------|----------|
 |`Class`| `string` |The CSS class that will be rendered on the `input` element|

--- a/components/datepicker/events.md
+++ b/components/datepicker/events.md
@@ -161,8 +161,6 @@ The `OnClose` event fires before the DatePicker popup closes.
 
 The event handler receives as an argument an `DatePickerCloseEventArgs` object that contains:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Property | Description |
 | --- | --- |
 | `IsCancelled` | Set the `IsCancelled` property to `true` to cancel the closing of the popup. |

--- a/components/datepicker/overview.md
+++ b/components/datepicker/overview.md
@@ -83,8 +83,6 @@ The date picker is, essentially, a [date input]({%slug components/dateinput/over
 
 The following parameters enable you to customize the appearance of the Blazor Date Picker:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Attribute | Type and Default Value | Description |
 |----------|----------|----------|
 | `Class` | `string` | The custom CSS class rendered on the wrapping element. |
@@ -100,8 +98,6 @@ You can find more options for customizing the Date Picker styling in the [Appear
 ## DatePicker Reference and Methods
 
 Add a reference to the component instance to use the [Date Picker's methods](/blazor-ui/api/Telerik.Blazor.Components.TelerikDatePicker-1).
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Method | Description |
 | --- | --- |

--- a/components/daterangepicker/events.md
+++ b/components/daterangepicker/events.md
@@ -152,8 +152,6 @@ The `OnClose` event fires before the DateRangePicker popup closes.
 
 The event handler receives as an argument an `DateRangePickerCloseEventArgs` object that contains:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Property | Description |
 | --- | --- |
 | `IsCancelled` | Set the `IsCancelled` property to `true` to cancel the closing of the popup. |

--- a/components/daterangepicker/overview.md
+++ b/components/daterangepicker/overview.md
@@ -81,8 +81,6 @@ The date range picker is, essentially, a [date input]({%slug components/dateinpu
 
 The following parameters enable you to customize the appearance of the Blazor Date Range Picker:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Attribute | Type and Default Value | Description |
 |----------|----------|----------|
 | `Class` | `string` | The CSS class that will be rendered on the main wrapping element of the Date Range Picker
@@ -95,8 +93,6 @@ You can find more options for customizing the Date Range Picker styling in the [
 ## DateRangePicker Reference and Methods
 
 Add a reference to the component instance to use the [Date Range Picker's methods](/blazor-ui/api/Telerik.Blazor.Components.TelerikDateRangePicker-1).
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Method | Description |
 | --- | --- |

--- a/components/datetimepicker/events.md
+++ b/components/datetimepicker/events.md
@@ -164,8 +164,6 @@ The `OnClose` event fires before the DateTimePicker popup closes.
 
 The event handler receives as an argument an `DateTimePickerCloseEventArgs` object that contains:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Property | Description |
 | --- | --- |
 | `IsCancelled` | Set the `IsCancelled` property to `true` to cancel the closing of the popup. |

--- a/components/datetimepicker/overview.md
+++ b/components/datetimepicker/overview.md
@@ -75,8 +75,6 @@ The time format specifiers in the `Format` control the tumblers available in the
 
 The following parameters enable you to customize the appearance of the Blazor DateTimePicker:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Attribute | Type and Default Value | Description |
 |----------|----------|----------|
 |`Class`| `string` |The CSS class that will be rendered on the `input` element|
@@ -90,8 +88,6 @@ You can find more options for customizing the DateTimePicker styling in the [App
 ## DateTimePicker Reference and Methods
 
 Add a reference to the component instance to use the [Date Time Picker's methods](/blazor-ui/api/Telerik.Blazor.Components.TelerikDateTimePicker-1).
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Method | Description |
 | --- | --- |

--- a/components/dialog/overview.md
+++ b/components/dialog/overview.md
@@ -88,8 +88,6 @@ The Blazor Dialog provides various parameters to configure the component. Also c
 
 The Dialog methods are accessible through its reference.
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Method | Description |
 | --- | --- |
 | `Refresh` | Redraws the component. |

--- a/components/dialog/overview.md
+++ b/components/dialog/overview.md
@@ -69,12 +69,8 @@ The Blazor Dialog fires a `VisibleChanged` event to customize the application be
 
 The Blazor Dialog provides various parameters to configure the component. Also check the [Dialog public API](https://docs.telerik.com/blazor-ui/api/Telerik.Blazor.Components.TelerikDialog).
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Parameter | Type and Default Value | Description |
 | --- | --- | --- |
 | `ButtonsLayout` | `DialogButtonsLayout` enum <br /> (`Stretched`) | Defines the layout of the actions button in the footer. See more in the [Action Buttons article]({%slug  dialog-action-buttons%})). |
@@ -92,12 +88,8 @@ The Blazor Dialog provides various parameters to configure the component. Also c
 
 The Dialog methods are accessible through its reference.
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Method | Description |
 | --- | --- |
 | `Refresh` | Redraws the component. |

--- a/components/drawer/overview.md
+++ b/components/drawer/overview.md
@@ -109,12 +109,8 @@ The Blazor Drawer fires select and expand events. Handle those events to respond
 
 The Blazor Drawer provides various parameters to configure the component. Also check the [Drawer public API](https://docs.telerik.com/blazor-ui/api/Telerik.Blazor.Components.TelerikDrawer-1).
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Parameter | Type and Default Value | Description |
 | --- | --- | --- |
 | `Class` | `string` | Renders a custom CSS class to the `<div class="k-drawer-container">` element. |
@@ -128,12 +124,8 @@ The Blazor Drawer provides various parameters to configure the component. Also c
 
 The Drawer methods are accessible through it's reference. These methods change the value of the `Expanded` parameter.
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Method | Description |
 | --- | --- |
 | `ExpandAsync` | Expands the Drawer. |

--- a/components/drawer/overview.md
+++ b/components/drawer/overview.md
@@ -124,8 +124,6 @@ The Blazor Drawer provides various parameters to configure the component. Also c
 
 The Drawer methods are accessible through it's reference. These methods change the value of the `Expanded` parameter.
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Method | Description |
 | --- | --- |
 | `ExpandAsync` | Expands the Drawer. |

--- a/components/dropdownlist/events.md
+++ b/components/dropdownlist/events.md
@@ -275,8 +275,6 @@ The `OnClose` event fires before the DropDownList popup closes.
 
 The event handler receives as an argument an `DropDownListCloseEventArgs` object that contains:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Property | Description |
 | --- | --- |
 | `IsCancelled` | Set the `IsCancelled` property to `true` to cancel the closing of the popup. |
@@ -322,8 +320,6 @@ The event handler receives as an argument an `DropDownListCloseEventArgs` object
 The `OnItemRender` event fires when each item in the DropDownList popup renders.
 
 The event handler receives as an argument an `DropDownListItemRenderEventArgs<TItem>` object that contains:
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Property | Description |
 | --- | --- |

--- a/components/dropdownlist/overview.md
+++ b/components/dropdownlist/overview.md
@@ -74,13 +74,8 @@ The Blazor DropDownList @[template](/_contentTemplates/dropdowns/features.md#gro
 
 >caption The DropDownList provides various parameters that allow you to configure the component:
 
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
 | Parameter      | Type | Description
 | ----------- | ----------- | -----------|
 | `Data` | `IEnumerable<TItem>` | allows you to provide the data source. Required.

--- a/components/editor/built-in-tools.md
+++ b/components/editor/built-in-tools.md
@@ -268,8 +268,6 @@ All tools in the table below are *buttons*, except `Format`, which is a *dropdow
 
 >caption Table 2: Block Tools of the Editor
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 <table>
     <thead>
         <tr>
@@ -398,8 +396,6 @@ All tools in the table below are *buttons*.
 
 >caption Table 3: Editor Table Tools
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 <table>
     <thead>
         <tr>
@@ -479,8 +475,6 @@ All tools in the table below are *buttons*.
 Some Editor commands have no built-in tools. These commands can only be [invoked programmatically](#programmatic-execution).
 
 >caption Table 4: Editor Commands Without Tools
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 <table>
     <thead>

--- a/components/filemanager/data-binding/overview.md
+++ b/components/filemanager/data-binding/overview.md
@@ -234,8 +234,6 @@ The above model properties have the following meaning for the FileManager:
 
 All [FileManager item features](#fileManager-item-features) map to model properties.  The properties of a treeview item match directly to a field of the model the treeview is bound to. You provide that relationship by providing the name of the field from which the corresponding information is to be taken. To do this, in the main `TelerikFileManager` tag, use the parameters described below:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | FileManager Parameter | DEFAULT VALUE |
 |----------|----------|----------|
 | **Item features** | |

--- a/components/filemanager/overview.md
+++ b/components/filemanager/overview.md
@@ -391,8 +391,6 @@ The following table lists the FileManager parameters. Also check the [FileManage
 
 The following parameters enable you to customize the appearance of the Blazor FileManager:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Parameter | Type and &nbsp; DefaultValue | Description |
 |----------|----------|----------|
 | `Class`| `string` |The CSS class that will be rendered on the topmost wrapping element of the component.

--- a/components/fileselect/events.md
+++ b/components/fileselect/events.md
@@ -22,12 +22,7 @@ The FileSelect event handlers provide a [`FileSelectEventArgs` argument](/blazor
 
 The `FileSelectFileInfo` type contains these properties:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 Property | Type | Description
 ---------|----------|---------

--- a/components/fileselect/overview.md
+++ b/components/fileselect/overview.md
@@ -109,12 +109,7 @@ The FileSelect includes [built-in client-side validation]({%slug fileselect-vali
 
 The following table lists the FileSelect parameters. Also check the [FileSelect API Reference](/blazor-ui/api/Telerik.Blazor.Components.TelerikFileSelect) for a full list of properties, methods and events.
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Parameter | Type and Default&nbsp;Value | Description |
 | --- | --- | --- |

--- a/components/floatinglabel/overview.md
+++ b/components/floatinglabel/overview.md
@@ -82,12 +82,7 @@ If a Telerik component has both a `Placeholder` and a floating label, the behavi
 
 The following table lists the FloatingLabel parameters. Also check the [FloatingLabel API Reference](https://docs.telerik.com/blazor-ui/api/Telerik.Blazor.Components.TelerikFloatingLabel) for a full list of properties, methods and events.
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Attribute | Type | Description |
 | --- | --- | --- |

--- a/components/form/overview.md
+++ b/components/form/overview.md
@@ -132,8 +132,6 @@ The following data types are supported out-of-the box and they use the following
 
 You can customize the automatically generated field by providing the `EditorType` attribute, exposed on the `<FormItem>`, or by using the [FormItem Template]({%slug form-formitems-template%}). The `EditorType` attribute accepts a member of the `FormEditorType` enum:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Field data type | FormEditorType enum members              |
 |-----------------|------------------------------------------|
 | **String**          | `FormEditorType.TextArea`<br /> `FormEditorType.TextBox` |
@@ -194,8 +192,6 @@ You can customize the editors further through the [form items]({%slug form-formi
 
 ## Form Parameters
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Parameter | Type and Default value | Description |
 |-----------|------------------------|-------------|
 | `Model`  | `object` | The object bound to the Form. It will automatically create the `EditContext` and using the two together is not supported. |
@@ -206,8 +202,6 @@ You can customize the editors further through the [form items]({%slug form-formi
 ### Form Layout Customization
 
 The Blazor Form exposes multiple parameters that allow you to customize its layout:
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Parameter | Type and Default value | Description |
 |-----------|------------------------|-------------|

--- a/components/gantt/gantt-tree/columns/bound.md
+++ b/components/gantt/gantt-tree/columns/bound.md
@@ -140,8 +140,6 @@ The Blazor Gantt Bound Column provides various parameters to configure the compo
 
 ### Appearance
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Parameter | Type and Default Value | Description |
 | --- | --- | --- |
 | `Title` | `string` | The text that is rendered in the column header. See the Notes below for its behavior. |

--- a/components/gantt/gantt-tree/columns/command.md
+++ b/components/gantt/gantt-tree/columns/command.md
@@ -46,8 +46,6 @@ See also Appearance properties like `Icon`, `Class`, `Enabled` that are coming f
 
 Built-in commands:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Command | Description |
 | --- | --- |
 | `Add` | Initiates the creation of a new item. Can apply to rows as well, to create a child element for the current row. |
@@ -56,8 +54,6 @@ Built-in commands:
 ### OnClick handler
 
 The `OnClick` handler of the commands receives an argument of type `GanttTaskCommandEventArgs` that exposes the following parameters:
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Parameter | Description |
 | --- | --- |

--- a/components/gauges/arc/overview.md
+++ b/components/gauges/arc/overview.md
@@ -58,8 +58,6 @@ The labels are rendered on the scale of the component to give information to the
 | `RenderAs` | `RenderingMode?` <br /> (`SVG`) | Controls if the gauge renders as `SVG` or `Canvas`. |
 
 ## Arc Gauge Reference and Methods
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
  
 | Method | Description |
 | --- | --- |

--- a/components/gauges/circular/overview.md
+++ b/components/gauges/circular/overview.md
@@ -69,8 +69,6 @@ The labels are rendered on the scale of the component to give information to the
 
 ## Circular Gauge Reference and Methods
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Method | Description |
 | --- | --- |
 | `Refresh` | Programatically re-render the Circular Gauge. |

--- a/components/gauges/linear/overview.md
+++ b/components/gauges/linear/overview.md
@@ -62,8 +62,6 @@ The ranges are used to visually distinguish particular values on the scale. [Rea
 
 
 ## Linear Gauge Reference and Methods
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
  
 | Method | Description |
 | --- | --- |

--- a/components/gauges/radial/overview.md
+++ b/components/gauges/radial/overview.md
@@ -65,8 +65,6 @@ The labels are rendered on the scale of the Radial Gauge to give inforation to t
 
 To execute Radial Gauge methods, obtain reference to the component instance via `@ref`.
 
- @[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Method  | Description |
 |---------|-------------|
 | Refresh | You can use that method to programmatically re-render the component.    |

--- a/components/loader/overview.md
+++ b/components/loader/overview.md
@@ -64,12 +64,7 @@ It is possible to place the Loader component inside another component for better
 
 The following table lists the Loader parameters. Also check the [Loader API Reference](/blazor-ui/api/Telerik.Blazor.Components.TelerikLoader).
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Parameter | Type and Default&nbsp;Value | Description |
 | --- | --- | --- |

--- a/components/loadercontainer/overview.md
+++ b/components/loadercontainer/overview.md
@@ -81,12 +81,7 @@ The Blazor LoaderContainer can expand to fill only a specific parent container. 
 
 The following table lists the LoaderContainer parameters. Also check the [LoaderContainer API Reference](/blazor-ui/api/Telerik.Blazor.Components.TelerikLoaderContainer).
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Parameter | Type and Default&nbsp;Value | Description |
 | --- | --- | --- |

--- a/components/maskedtextbox/overview.md
+++ b/components/maskedtextbox/overview.md
@@ -58,8 +58,6 @@ The table below provides a quick overview of the mask-related parameters. You ca
 
 ## MaskedTextBox Parameters
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Parameter | Type and Default value | Description |
 |-----------|------------------------|-------------|
 | `Class`  | `string` | Adds a custom CSS class to the `<div class="k-maskedtextbox">` element. |

--- a/components/multicolumncombobox/events.md
+++ b/components/multicolumncombobox/events.md
@@ -428,8 +428,6 @@ The `OnClose` event fires before the MultiColumnComboBox popup closes.
 
 The event handler receives as an argument an `MultiColumnComboBoxCloseEventArgs` object that contains:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Property | Description |
 | --- | --- |
 | `IsCancelled` | Set the `IsCancelled` property to `true` to cancel the closing of the popup. |

--- a/components/multicolumncombobox/overview.md
+++ b/components/multicolumncombobox/overview.md
@@ -131,8 +131,6 @@ The MultiColumnComboBox @[template](/_contentTemplates/dropdowns/features.md#gro
 
 The following parameters enable you to customize the appearance of the Blazor MultiColumnComboBox:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 @[template](/_contentTemplates/dropdowns/features.md#styling)
 
 You can find more options for customizing the MultiColumnComboBox styling in the [Appearance article]({%slug multicolumncombobox-appearance%}).
@@ -154,8 +152,6 @@ The popup of the component can be additionally customized via nested tags:
 
 The MultiColumnComboBox provides the following popup settings:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `AnimationDuration` | `int` | The animation duration of the popup in milliseconds. |
@@ -171,8 +167,6 @@ To execute MultiColumnComboBox methods, obtain reference to the component instan
 The MultiColumnComboBox is a generic component. Its type depends on the type of its model and the type of its `Value`. In case you cannot provide either the `Value` or `Data` initially, you need to [set the corresponding types to the `TItem` and `TValue` parameters]({%slug common-features-data-binding-overview%}#component-type).
 
 The table below lists the MultiComboBox methods. Also consult the [MultiColumnComboBox API](/blazor-ui/api/Telerik.Blazor.Components.TelerikMultiColumnComboBox-2).
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Method | Description |
 | --- | --- |

--- a/components/multiselect/events.md
+++ b/components/multiselect/events.md
@@ -270,8 +270,6 @@ The `OnClose` event fires before the MultiSelect popup closes.
 
 The event handler receives as an argument an `MultiSelectCloseEventArgs` object that contains:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Property | Description |
 | --- | --- |
 | `IsCancelled` | Set the `IsCancelled` property to `true` to cancel the closing of the popup. |
@@ -317,8 +315,6 @@ The event handler receives as an argument an `MultiSelectCloseEventArgs` object 
 The `OnItemRender` event fires when each item in the MultiSelect dropdown renders. 
 
 The event handler receives as an argument an `MultiSelectItemRenderEventArgs<TItem>` object that contains:
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Property | Description |
 | --- | --- |

--- a/components/notification/overview.md
+++ b/components/notification/overview.md
@@ -111,8 +111,6 @@ You can [customize the styling and the appearance of the Notification]({%slug no
 
 The `NotificationModel` class is used to add new notifications to the page. You can use it to set settings for each individual message you want to show. The class contains the following properties:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Property | Type and Default value | Description |
 |-----------|------------------------|-------------|
 | `ThemeColor`  | `string` | The color of the notification is controlled through this parameter. You can find more infomation and examples in the [Appearance]({%slug notification-appearance%}) article. |

--- a/components/numerictextbox/overview.md
+++ b/components/numerictextbox/overview.md
@@ -95,8 +95,6 @@ The Blazor Numeric TextBox allows you to define your desired custom format throu
 
 The following parameters enable you to customize the appearance of the Blazor Numeric TextBox:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Attribute | Type and Default Value | Description |
 |----------|----------|----------|
 |`Class`| `string` |The CSS class that will be rendered on the topmost wrapping elementof teh component.|

--- a/components/pager/overview.md
+++ b/components/pager/overview.md
@@ -76,12 +76,8 @@ The Blazor Pager exposes PageChanged and PageSizeChanged events that you can han
 
 The Blazor Pager provides various parameters that allow you to configure the component:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Parameter | Type and Default Value | Description |
 | ----------- | ----------- | ----------- |
 |`Adaptive` | `bool` | Defines whether pager elements should be changed based on the screen size. When enabled, the Pager will hide its `Pager Info` and `PageSize Dropdownlist` if they cannot fit in the available space. In the smallest resolution, the page buttons will be rendered as a select element.

--- a/components/panelbar/overview.md
+++ b/components/panelbar/overview.md
@@ -158,8 +158,6 @@ The PanelBar is a generic component. Its type depends on the type of its model a
 
 The table below lists the PanelBar methods. Also consult the [PanelBar API](/blazor-ui/api/Telerik.Blazor.Components.TelerikPanelBar).
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Method | Description |
 | --- | --- |
 | `Rebind` | [Refreshes the component data]({%slug panelbar-refresh-data%}#rebind-method). |

--- a/components/pdfviewer/overview.md
+++ b/components/pdfviewer/overview.md
@@ -93,8 +93,6 @@ The table below lists the PDF Viewer parameters. Also check the [PDF Viewer API 
 
 The PdfViewer exposes methods for programmatic operation. To use them, define a reference to the component instance with the `@ref` directive attribute.
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Method | Description |
 | --- | --- |
 | `Rebind` | Refreshes the PDF Viewer and ensures it is displaying the latest file `Data`. [`Rebind` is necessary when the Blazor framework cannot re-render components automatically]({%slug common-features-data-binding-overview%}#refresh-data). |

--- a/components/radiogroup/appearance.md
+++ b/components/radiogroup/appearance.md
@@ -19,12 +19,8 @@ You can control the appearance of the RadioButtonGroup button by setting the fol
 
 Change the size of the radio buttons by setting the `Size` parameter to a member of the `Telerik.Blazor.ThemeConstants.Button.Size` class:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Class members | Manual declarations |
 |---------------|--------|
 |`Small`|`sm`|

--- a/components/radiogroup/overview.md
+++ b/components/radiogroup/overview.md
@@ -79,12 +79,8 @@ The Blazor RadioGroup fires blur and value change events to respond to user acti
 
 The Blazor RadioGroup provides various parameters to configure the component. Also check the [RadioGroup public API](https://docs.telerik.com/blazor-ui/api/Telerik.Blazor.Components.TelerikRadioGroup-2).
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Parameter | Type and Default Value | Description |
 | --- | --- | --- |
 | `Class` | `string` | The custom CSS class for the main wrapping element, which is `<ul class="k-radio-list">`. |

--- a/components/slider/overview.md
+++ b/components/slider/overview.md
@@ -82,12 +82,8 @@ You can validate Slider value using the built-in validation. See the [Input Vali
 
 The Slider provides various parameters that allow you to configure the component:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Parameter    | Type  | Description |
 | ----------- | ----------- | -------|
 | `Decimals` | `int` | Specifies the number precision for the steps.

--- a/components/splitbutton/icons.md
+++ b/components/splitbutton/icons.md
@@ -19,12 +19,7 @@ The SplitButton provides four parameters and five different ways to add an icon 
 
 The `string` parameters below exist for both `TelerikSplitButton` and `SplitButtonItem`.
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Parameter | Intended Usage |
 | --- | --- |

--- a/components/splitbutton/overview.md
+++ b/components/splitbutton/overview.md
@@ -99,8 +99,6 @@ The SplitButton exposes configuration settings for its dropdown (popup). The par
 </TelerikSplitButton>
 ````
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Parameter | Type and Default&nbsp;Value | Description |
 | --- | --- | --- |
 | `AnimationDuration` | `int` <br /> (`300`) | Sets the dropdown animation duration in milliseconds. |
@@ -118,8 +116,6 @@ The SplitButton exposes configuration settings for its dropdown (popup). The par
 ### Item Settings
 
 The following table lists the `SplitButtonItem` parameters, except those related to [icons]({%slug splitbutton-icons%}).
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Parameter | Type and Default&nbsp;Value | Description |
 | --- | --- | --- |

--- a/components/splitbutton/overview.md
+++ b/components/splitbutton/overview.md
@@ -73,12 +73,7 @@ Each SplitButton action [fires a separate `OnClick` event]({%slug splitbutton-ev
 
 The following table lists the SplitButton parameters, except those related to [built-in styling]({%slug splitbutton-appearance%}) and [icons]({%slug splitbutton-icons%}). Also check the [SplitButton API Reference](/blazor-ui/api/Telerik.Blazor.Components.TelerikSplitButton) for a full list of properties, methods and events.
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Parameter | Type and Default&nbsp;Value | Description |
 | --- | --- | --- |
@@ -104,12 +99,7 @@ The SplitButton exposes configuration settings for its dropdown (popup). The par
 </TelerikSplitButton>
 ````
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Parameter | Type and Default&nbsp;Value | Description |
 | --- | --- | --- |
@@ -129,12 +119,7 @@ The SplitButton exposes configuration settings for its dropdown (popup). The par
 
 The following table lists the `SplitButtonItem` parameters, except those related to [icons]({%slug splitbutton-icons%}).
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Parameter | Type and Default&nbsp;Value | Description |
 | --- | --- | --- |

--- a/components/splitter/overview.md
+++ b/components/splitter/overview.md
@@ -98,8 +98,6 @@ Check the [Splitter API Reference ](https://docs.telerik.com/blazor-ui/api/Teler
 
 Add a reference to the component instance to use the [Splitter methods](https://docs.telerik.com/blazor-ui/api/Telerik.Blazor.Components.TelerikSplitter#methods).
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Method | Description |
 | --- | --- |
 | `GetState` | Gets the current [state]({%slug splitter-state%}) of the Splitter.

--- a/components/stacklayout/overview.md
+++ b/components/stacklayout/overview.md
@@ -60,12 +60,8 @@ The layout is the building block of the StackLayout component. Control its appea
 
 The Blazor StackLayout provides various parameters that allow you to configure the component:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Parameter | Type and Default Value | Description |
 | ----------- | ----------- | ----------- |
 | `Class` | `string` | The CSS class to be rendered on the main wrapping element of the StackLayout component, which is `<div class="k-stack-layout">`. Use for [styling customizations]({%slug themes-override%}). |

--- a/components/stepper/overview.md
+++ b/components/stepper/overview.md
@@ -75,12 +75,8 @@ The Blazor Stepper generates events that you can handle and further customize it
 
 The Blazor Stepper provides various parameters that allow you to configure the component:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Parameter | Type and Default Value | Description |
 | ----------- | ----------- | ----------- |
 | `Value` | `int` | Defines the current step index. |

--- a/components/stepper/steps/overview.md
+++ b/components/stepper/steps/overview.md
@@ -27,12 +27,8 @@ The `StepperStep` exposes the following parameters which allow you to configure 
 
 The [visual indicators]({%slug stepper-indicators%}) of the steps can include the content below.
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Parameter | Type and Default Value | Description |
 | ----------- | ----------- | ----------- |
 | `Text` | `string` | Specifies the step indicator text. |
@@ -45,12 +41,8 @@ The [visual indicators]({%slug stepper-indicators%}) of the steps can include th
 
 The steps can have one of the [states]({%slug stepper-state%}) below.
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Parameter | Type and Default Value | Description |
 | ----------- | ----------- | ----------- |
 | `Disabled` | `bool` <br /> (`false`) | Specifies if the step is disabled. |
@@ -58,12 +50,8 @@ The steps can have one of the [states]({%slug stepper-state%}) below.
 
 ### Other parameters
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Parameter | Type and Default Value | Description |
 | ----------- | ----------- | ----------- |
 | `Label` | `string` | Specifies the [label text]({%slug stepper-labels%}) that will be rendered under the corresponding step indicator. |

--- a/components/stepper/steps/overview.md
+++ b/components/stepper/steps/overview.md
@@ -41,16 +41,12 @@ The [visual indicators]({%slug stepper-indicators%}) of the steps can include th
 
 The steps can have one of the [states]({%slug stepper-state%}) below.
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Parameter | Type and Default Value | Description |
 | ----------- | ----------- | ----------- |
 | `Disabled` | `bool` <br /> (`false`) | Specifies if the step is disabled. |
 | `Optional` | `bool` <br /> (`false`) | Specifies if the step is optional. |
 
 ### Other parameters
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Parameter | Type and Default Value | Description |
 | ----------- | ----------- | ----------- |

--- a/components/stockchart/overview.md
+++ b/components/stockchart/overview.md
@@ -246,8 +246,6 @@ The following table lists StockChart parameters, which are not discussed elsewhe
 
 To execute StockChart methods, obtain reference to the component instance via `@ref`.
 
- @[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Method  | Description |
 |---------|-------------|
 | Refresh | You can use that method to programmatically re-render the component. |

--- a/components/switch/overview.md
+++ b/components/switch/overview.md
@@ -68,8 +68,6 @@ The following table lists the Switch parameters. Also check the [Switch API Refe
 
 The following parameters enable you to customize the appearance of the Blazor Switch:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Attribute | Type and Default Value | Description |
 |----------|----------|----------|
 | `Class` | `string` | The CSS class that will be rendered on the main wrapping element of the Switch. Use it to [customize the Switch background color and other styles]({%slug switch-kb-change-background-color%})
@@ -80,8 +78,6 @@ You can find more options for customizing the Switch styling in the [Appearance 
 ## Switch Reference and Methods
 
 The Switch is a generic component and its type comes from the model field it is bound to - it is either `bool` or `bool?` (a `null` value is treated as `false`). Add a reference to the component instance to use the [Switch methods](https://docs.telerik.com/blazor-ui/api/Telerik.Blazor.Components.TelerikSwitch-1#methods).
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Method | Description |
 | --- | --- |

--- a/components/tabstrip/overview.md
+++ b/components/tabstrip/overview.md
@@ -77,8 +77,6 @@ The TabStrip provides the following features to allow further customization of i
 
 The following parameters enable you to customize the appearance of the Blazor TabStrip:.
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Parameter | Type     | Description                              |
 |-----------|----------|------------------------------------------|
 | `Class`   | `string` | The CSS class that will be rendered on the main wrapping element of the component. |

--- a/components/textarea/appearance.md
+++ b/components/textarea/appearance.md
@@ -21,12 +21,8 @@ You can control the appearance of the TextArea button by setting the following a
 
 You can increase or decrease the size of the TextArea by setting the `Size` attribute to a member of the `Telerik.Blazor.ThemeConstants.TextArea.Size` class:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Class members | Manual declarations |
 |------------|--------|
 |`Small` |`sm`|
@@ -62,12 +58,8 @@ You can increase or decrease the size of the TextArea by setting the `Size` attr
 
 The `Rounded` attribute applies the `border-radius` CSS rule to the TextArea to achieve curving of the edges. You can set it to a member of the `Telerik.Blazor.ThemeConstants.TextArea.Rounded` class:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Class members | Manual declarations |
 |------------|--------|
 |`Small` |`sm`|
@@ -106,12 +98,8 @@ The `Rounded` attribute applies the `border-radius` CSS rule to the TextArea to 
 
 The `FillMode` controls how the TelerikTextArea is filled. You can set it to a member of the `Telerik.Blazor.ThemeConstants.TextArea.FillMode` class:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Class members | Result |
 |------------|--------|
 |`Solid` <br /> default value|`solid`|

--- a/components/textarea/appearance.md
+++ b/components/textarea/appearance.md
@@ -58,8 +58,6 @@ You can increase or decrease the size of the TextArea by setting the `Size` attr
 
 The `Rounded` attribute applies the `border-radius` CSS rule to the TextArea to achieve curving of the edges. You can set it to a member of the `Telerik.Blazor.ThemeConstants.TextArea.Rounded` class:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Class members | Manual declarations |
 |------------|--------|
 |`Small` |`sm`|
@@ -97,8 +95,6 @@ The `Rounded` attribute applies the `border-radius` CSS rule to the TextArea to 
 ## FillMode
 
 The `FillMode` controls how the TelerikTextArea is filled. You can set it to a member of the `Telerik.Blazor.ThemeConstants.TextArea.FillMode` class:
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Class members | Result |
 |------------|--------|

--- a/components/textarea/overview.md
+++ b/components/textarea/overview.md
@@ -43,12 +43,8 @@ The Blazor TextArea fires **blur** and value **change** events to respond to use
 
 The Blazor TextArea provides various parameters to configure the component:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Parameter | Type and Default Value | Description |
 | ----------- | ----------- | ----------- |
 | `Value` | `string` | Get/set the value of the input, can be used for binding. |

--- a/components/textbox/appearance.md
+++ b/components/textbox/appearance.md
@@ -21,12 +21,8 @@ You can control the appearance of the TextBox button by setting the following at
 
 You can increase or decrease the size of the TextBox by setting the `Size` attribute to a member of the `Telerik.Blazor.ThemeConstants.TextBox.Size` class:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Class members | Manual declarations |
 |------------|--------|
 |`Small` |`sm`|
@@ -62,12 +58,8 @@ You can increase or decrease the size of the TextBox by setting the `Size` attri
 
 The `Rounded` attribute applies the `border-radius` CSS rule to the textbox to achieve curving of the edges. You can set it to a member of the `Telerik.Blazor.ThemeConstants.TextBox.Rounded` class:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Class members | Manual declarations |
 |------------|--------|
 |`Small` |`sm`|
@@ -106,12 +98,8 @@ The `Rounded` attribute applies the `border-radius` CSS rule to the textbox to a
 
 The `FillMode` controls how the TelerikTextBox is filled. You can set it to a member of the `Telerik.Blazor.ThemeConstants.TextBox.FillMode` class:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Class members | Result |
 |------------|--------|
 |`Solid` <br /> default value|`solid`|

--- a/components/textbox/appearance.md
+++ b/components/textbox/appearance.md
@@ -58,8 +58,6 @@ You can increase or decrease the size of the TextBox by setting the `Size` attri
 
 The `Rounded` attribute applies the `border-radius` CSS rule to the textbox to achieve curving of the edges. You can set it to a member of the `Telerik.Blazor.ThemeConstants.TextBox.Rounded` class:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Class members | Manual declarations |
 |------------|--------|
 |`Small` |`sm`|
@@ -97,8 +95,6 @@ The `Rounded` attribute applies the `border-radius` CSS rule to the textbox to a
 ## FillMode
 
 The `FillMode` controls how the TelerikTextBox is filled. You can set it to a member of the `Telerik.Blazor.ThemeConstants.TextBox.FillMode` class:
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Class members | Result |
 |------------|--------|

--- a/components/textbox/overview.md
+++ b/components/textbox/overview.md
@@ -43,12 +43,8 @@ The Blazor TextBox generates blur and value change events for further customizin
 
 The Blazor TextBox provides various parameters to configure the component:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Parameter | Type and Default Value | Description |
 | ----------- | ----------- | ----------- |
 | `Value` | `string` | Get/set the value of the input, can be used for binding. |

--- a/components/tilelayout/overview.md
+++ b/components/tilelayout/overview.md
@@ -96,8 +96,6 @@ The following table lists the Tile Layout parameters. Also check the [TileLayout
 
 ### TileLayoutItem Parameters
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Parameter | Type and Default&nbsp;Value | Description |
 | --- | --- | --- |
 | `Class` | `string` | The custom CSS class of the `<div class="k-tilelayout-item">` element. Use it to [override theme styles]({%slug themes-override%}). |
@@ -110,8 +108,6 @@ The following table lists the Tile Layout parameters. Also check the [TileLayout
 ## TileLayout Reference
 
 Use the component reference to execute methods and [get or set the TileLayout state]({%slug tilelayout-state%}).
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Method | Description |
 | --- | --- |

--- a/components/timepicker/events.md
+++ b/components/timepicker/events.md
@@ -163,8 +163,6 @@ The `OnClose` event fires before the TimePicker popup closes.
 
 The event handler receives as an argument an `TimePickerCloseEventArgs` object that contains:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Property | Description |
 | --- | --- |
 | `IsCancelled` | Set the `IsCancelled` property to `true` to cancel the closing of the popup. |

--- a/components/timepicker/overview.md
+++ b/components/timepicker/overview.md
@@ -85,8 +85,6 @@ The Blazor Time Picker component provides various parameters that allow you to c
 
 The following parameters enable you to customize the appearance of the Blazor Time Picker:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Attribute | Type and Default Value | Description |
 |----------|----------|----------|
 | `Class` | `string` | The custom CSS class rendered on the wrapping element.
@@ -100,8 +98,6 @@ You can find more options for customizing the Time Picker styling in the [Appear
 ## TimePicker Reference and Methods
 
 Add a reference to the component instance to use the [Time Picker's methods](/blazor-ui/api/Telerik.Blazor.Components.TelerikTimePicker-1).
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Method | Description |
 | --- | --- |

--- a/components/toolbar/built-in-tools.md
+++ b/components/toolbar/built-in-tools.md
@@ -26,12 +26,8 @@ You can add multiple buttons to the Telerik Toolbar. To do that you should add t
 
 The nested `ToolBarButton` tag exposes parameters that allow you to customize the buttons:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Parameter | Type and Default Value | Description |
 | ----------- | ----------- | ----------- |
 | `Class` | `string` | The CSS class that will be rendered on the main wrapping element of the ToolbarButton. You could use that class to cascade styles. |
@@ -86,12 +82,8 @@ You can add multiple toggle  buttons to the Telerik Toolbar. To do that you shou
 
 The nested `ToolBarToggleButton` tag exposes parameters that allow you to customize the buttons:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Parameter | Type and Default Value | Description |
 | ----------- | ----------- | ----------- |
 | `Class` | `string` | The CSS class that will be rendered on the main wrapping element of the ToolbarButton. You could use that class to cascade styles. |
@@ -150,12 +142,8 @@ You can add one or more group of buttons to the Toolbar. To do that you should a
 
 The nested `ToolBarButtonGroup` tag exposes parameters that allow you to customize the buttons:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 | Parameter | Type and Default Value | Description |
 | ----------- | ----------- | ----------- |
 | `Class` | `string` | The CSS class that will be rendered on the main wrapping element of the ToolBarButtonGroup. You could use that class to cascade styles. |

--- a/components/toolbar/built-in-tools.md
+++ b/components/toolbar/built-in-tools.md
@@ -82,8 +82,6 @@ You can add multiple toggle  buttons to the Telerik Toolbar. To do that you shou
 
 The nested `ToolBarToggleButton` tag exposes parameters that allow you to customize the buttons:
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Parameter | Type and Default Value | Description |
 | ----------- | ----------- | ----------- |
 | `Class` | `string` | The CSS class that will be rendered on the main wrapping element of the ToolbarButton. You could use that class to cascade styles. |
@@ -141,8 +139,6 @@ You can add one or more group of buttons to the Toolbar. To do that you should a
 ### ToolBarButtonGroup parameters
 
 The nested `ToolBarButtonGroup` tag exposes parameters that allow you to customize the buttons:
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Parameter | Type and Default Value | Description |
 | ----------- | ----------- | ----------- |

--- a/components/toolbar/overview.md
+++ b/components/toolbar/overview.md
@@ -78,12 +78,7 @@ The Blazor ToolBar fires click and selection events. Handle those events to resp
 
 The Blazor ToolBar provides parameters to configure the component:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Parameter | Type | Description |
 | ----------- | ----------- | ----------- |

--- a/components/treeview/data-binding/overview.md
+++ b/components/treeview/data-binding/overview.md
@@ -44,10 +44,9 @@ public class TreeItem
 
 The above model properties have the following meaning for the TreeView:
 
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
+
 <style>
-    style + table {
-        table-layout: auto;
-    }
     style + table td {
         vertical-align: top;
     }

--- a/components/treeview/overview.md
+++ b/components/treeview/overview.md
@@ -145,8 +145,6 @@ The TreeView is a generic component. Its type depends on the type of its model a
 
 The table below lists the TreeView methods. Also consult the [TreeView API](/blazor-ui/api/Telerik.Blazor.Components.TelerikTreeView).
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Method | Description |
 | --- | --- |
 | `Rebind` | [Refreshes the component data]({%slug treeview-refresh-data%}#rebind-method). |

--- a/components/upload/overview.md
+++ b/components/upload/overview.md
@@ -178,12 +178,7 @@ The Upload `MaxFileSize` parameter is used only for [client-side validation]({%s
 
 The following table lists the Upload parameters. Also check the [Upload API Reference](/blazor-ui/api/Telerik.Blazor.Components.TelerikUpload) for a full list of properties, methods and events.
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Parameter | Type and Default&nbsp;Value | Description |
 | --- | --- | --- |

--- a/components/window/actions.md
+++ b/components/window/actions.md
@@ -25,12 +25,7 @@ To define action buttons, populate the `WindowActions` tag of the Window with `W
 
 Action buttons expose the following properties:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Parameter | Type and Default&nbsp;Value | Description |
 | --- | --- | --- |

--- a/components/window/overview.md
+++ b/components/window/overview.md
@@ -70,12 +70,7 @@ The Window component can be responsive when the browser window size changes. Her
 
 The following table lists the Window parameters, which are not discussed elsewhere in the component documentation. Also check the [Window API](/blazor-ui/api/Telerik.Blazor.Components.TelerikWindow) for a full list of parameters and events.
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Parameter | Type and Default&nbsp;Value | Description |
 | --- | --- | --- |

--- a/components/window/size.md
+++ b/components/window/size.md
@@ -64,12 +64,7 @@ The user can maximize and minimize the Window through [action buttons in its tit
 
 You can invoke those actions by setting the `State` parameter. It takes a member of the `Telerik.Blazor.WindowState` enum:
 
-<style>
-    article style + table {
-        table-layout: auto;
-        word-break: normal;
-    }
-</style>
+@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | `WindowState`&nbsp;Value | Description |
 | --- | --- |

--- a/styling-and-themes/swatch-distribution.md
+++ b/styling-and-themes/swatch-distribution.md
@@ -50,8 +50,6 @@ The CDN URLs contain the Telerik UI for Blazor version. Thus, you do not need to
 
 #### Default
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 Swatch | CDN |
 | ----------- | ----------- |
 | Main | https://blazor.cdn.telerik.com/blazor/{{site.uiForBlazorLatestVersion}}/kendo-theme-default/swatches/default-main.css
@@ -64,8 +62,6 @@ Swatch | CDN |
 
 #### Bootstrap
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 Swatch | CDN |
 | ----------- | ----------- |
 | Main | https://blazor.cdn.telerik.com/blazor/{{site.uiForBlazorLatestVersion}}/kendo-theme-bootstrap/swatches/bootstrap-main.css
@@ -75,8 +71,6 @@ Swatch | CDN |
 | Vintage | https://blazor.cdn.telerik.com/blazor/{{site.uiForBlazorLatestVersion}}/kendo-theme-bootstrap/swatches/bootstrap-vintage.css
 
 #### Material
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 Swatch | CDN |
 | ----------- | ----------- |
@@ -88,8 +82,6 @@ Swatch | CDN |
 
 
 #### Fluent
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 Swatch | CDN |
 | ----------- | ----------- |

--- a/styling-and-themes/theme-swatches.md
+++ b/styling-and-themes/theme-swatches.md
@@ -62,8 +62,6 @@ Here is a complete list of the base themes, all available swatches and their CDN
 
 ### Bootstrap
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | Swatch | CDN |
 | ----------- | ----------- |
 | Bootstrap Main | https://cdn.kendostatic.com/themes/{{site.themeCdnVersion}}/bootstrap/bootstrap-main.css
@@ -80,8 +78,6 @@ Here is a complete list of the base themes, all available swatches and their CDN
 
 
 ### Material
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Swatch | CDN |
 | ----------- | ----------- |
@@ -101,8 +97,6 @@ Here is a complete list of the base themes, all available swatches and their CDN
 | Material Smoke | https://cdn.kendostatic.com/themes/{{site.themeCdnVersion}}/material/material-smoke.css
 
 ### Fluent
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Swatch | CDN |
 | ----------- | ----------- |

--- a/system-requirements.md
+++ b/system-requirements.md
@@ -44,8 +44,6 @@ A **compatible .NET version** is one that is *no longer* (or *not yet*) official
 
 >caption .NET versions that are compatible with Telerik UI for Blazor
 
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
-
 | .NET version | First UI for Blazor Version | Last UI for Blazor Version |
 | --- | --- | --- |
 | .NET 7 Preview ([see below](#preview-net-versions)) | 3.3.0 | N/A |
@@ -63,8 +61,6 @@ Telerik UI for Blazor is committed to the currently supported official versions 
 Use these browsers to access web applications with Telerik UI for Blazor.
 
 >caption Browsers supported by Telerik UI for Blazor
-
-@[template](/_contentTemplates/common/parameters-table-styles.md#table-layout)
 
 | Browser | Supported Versions |
 | ----------- | ----------- |


### PR DESCRIPTION
1. Replaced `<style>` tags with reusable template everywhere.
2. Changed the CSS combinator, so that only one template is necessary per page.