### PR TITLE
docs(common): Remove .html from API pages that end with .resources

### DIFF
--- a/web.config
+++ b/web.config
@@ -68,10 +68,6 @@
                     <match url="^$" />
                     <action type="Redirect" url="introduction" />
                 </rule>
-                <rule name="redirect_resources" enabled="true" stopProcessing="true">
-                    <match url="(.*)\.Resources\.html$" />
-                    <action type="None" />
-                </rule>
                 <rule name="remove_html_extension" enabled="true" stopProcessing="true">
                     <match url="(.*)\.html$" />
                     <action type="Redirect" url="{R:1}" />
@@ -105,5 +101,15 @@
          <error statusCode="404" path="40x.html" />
        </httpErrors>
     </system.webServer>
-
+    <location path="api">
+        <system.webServer>
+            <security>
+             <requestFiltering>
+                <fileExtensions>
+                   <remove fileExtension=".resources" />
+                </fileExtensions>
+             </requestFiltering>
+            </security>
+        </system.webServer>
+    </location>
 </configuration>


### PR DESCRIPTION
PR by Niki Nenkov. The goal is to fix page URLs like this one - http://docs.telerik.com/blazor-ui/api/Telerik.Blazor.Resources.html