### PR TITLE
docs(icons): Fix exampels in Icons artcles

### DIFF
--- a/components/breadcrumb/icons.md
+++ b/components/breadcrumb/icons.md
@@ -10,12 +10,29 @@ position: 10
 
 # Breadcrumb Icons
 
-You can add a [Telerik Font or SVG icon]({%slug general-information/font-icons%}) to the Breadcrumb item by assigning a `string` to the `IconField` parameter.
+You can add [Telerik Font or SVG icons]({%slug general-information/font-icons%}) to the Breadcrumb items. The component also supports custom icons.
 
->caption How to use icons in Telerik Breadcrumb.
+To use Breadcrumb icons, define a property in the component model class and assign the property name to the `IconField` parameter of the Breadcrumb. The model property can hold a `FontIcon` enum, an `ISvgIcon`, or a `string` that signifies a CSS class.
+
+If the icon property name in the Breadcrumb model is `Icon`, there is no need to set the `IconField` parameter.
+
+>caption How to use icons in Telerik Breadcrumb
 
 ````CSHTML
-    <TelerikBreadcrumb Data="@Data"></TelerikBreadcrumb>
+<TelerikBreadcrumb Data="@Data"></TelerikBreadcrumb>
+
+<style>
+    /* Third-party icon libraries should provide these styles out-of-the-box. */
+    /* You may need two CSS classes for the same element - 
+        one for base icon styles and one for the specific icon glyph. */
+
+    .my-icon {
+        width: 1em;
+        height: 1em;
+        font-size: 16px;
+        background: purple;
+    }
+</style>
 
 @code {
     public IEnumerable<BreadcrumbItem> Data = new List<BreadcrumbItem>();
@@ -24,11 +41,12 @@ You can add a [Telerik Font or SVG icon]({%slug general-information/font-icons%}
     {
         Data = new List<BreadcrumbItem>
         {
-            new BreadcrumbItem { Title = "Home", Icon = FontIcon.Home },
+            new BreadcrumbItem { Title = "Home (Font)", Icon = FontIcon.Home },
             new BreadcrumbItem { Text = "General", Icon = FontIcon.Globe, Disabled = true },
             new BreadcrumbItem { Text = "Activities" },
-            new BreadcrumbItem { Text = "Drawing", Icon = FontIcon.Palette },
-            new BreadcrumbItem { Icon = FontIcon.Photos },
+            new BreadcrumbItem { Text = "Drawing (SVG)", Icon = SvgIcon.Palette },
+            new BreadcrumbItem { Text = "Custom", Icon = "my-icon" },
+            new BreadcrumbItem { Icon = SvgIcon.Photos }
         };
     }
 
@@ -36,7 +54,7 @@ You can add a [Telerik Font or SVG icon]({%slug general-information/font-icons%}
     {
         public string Text { get; set; }
         public string Title { get; set; }
-        public FontIcon? Icon { get; set; }
+        public object Icon { get; set; }
         public bool Disabled { get; set; }
     }
 }

--- a/components/contextmenu/icons.md
+++ b/components/contextmenu/icons.md
@@ -10,46 +10,81 @@ position: 15
 
 # Context Menu Icons
 
-You can add a [Telerik Font or SVG icon]({%slug general-information/font-icons%}) to the ContextMenu item by assigning a `string` to the `IconField` parameter.
+You can add [Telerik Font or SVG icons]({%slug general-information/font-icons%}) to the ContextMenu items. The component also supports custom icons.
+
+To use ContextMenu item icons, define a property in the component model class and assign the property name to the `IconField` parameter of the ContextMenu. The model property can hold a `FontIcon` enum, an `ISvgIcon`, or a `string` that signifies a CSS class.
+
+If the icon property name in the ContextMenu model is `Icon`, there is no need to set the `IconField` parameter.
 
 >caption How to use icons in Telerik Context Menu
 
 ````CSHTML
-<div id="context-menu-target" style="background:yellow;">right click for context menu</div>
+<div class="context-menu-target" style="width:200px; height: 100px; background: yellow; margin-bottom: 50px;">
+    Right click (or tap-and-hold on a touch device) for a context menu.
+</div>
 
 <TelerikContextMenu Data="@MenuData"
-                    Selector="#context-menu-target"
-                    IconField="@nameof(MenuModel.TelerikFontIcon)">
+                    Selector=".context-menu-target"
+                    IconField="@(nameof(MenuItem.Icon))">
 </TelerikContextMenu>
 
+<style>
+    /* Third-party icon libraries should provide these styles out-of-the-box. */
+
+    /* base styles for all custom icons */
+    .my-icon {
+        /* Define size, position and font styles here. */
+        width: 1em;
+        height: 1em;
+        font-size: 16px;
+    }
+
+    /* styles for specific custom icons */
+    .my-icon-purple {
+        /* define a background image or a font icon glyph here */
+        background: purple;
+    }
+</style>
+
 @code {
-    public List<MenuModel> MenuData { get; set; }
+    public List<MenuItem> MenuData { get; set; }
 
     protected override void OnInitialized()
     {
-        GenerateMenuData();
-    }
-
-    public void GenerateMenuData()
-    {
-        MenuData = new List<MenuModel>()
+        MenuData = new List<MenuItem>()
         {
-            new MenuModel()
+            new MenuItem()
             {
                 Text = "Font Icon",
-                TelerikFontIcon = FontIcon.Envelop
+                Icon = FontIcon.Envelop
+            },
+            new MenuItem()
+            {
+                Text = "SVG Icon",
+                Icon = SvgIcon.Wrench,
+            },
+            new MenuItem()
+            {
+                Text = "Custom Icon",
+                Icon = "my-icon my-icon-purple"
+            },
+            new MenuItem()
+            {
+                Text = "Empty Icon",
+                Icon = "my-icon"
             }
         };
     }
 
-    public class MenuModel
+    public class MenuItem
     {
         public string Text { get; set; }
-        public FontIcon? TelerikFontIcon { get; set; }
+        public object Icon { get; set; }
     }
 }
 ````
 
 ## See Also
 
-  * [Context Menu Overview]({%slug contextmenu-overview%})
+* [Online Demo: Context Menu Icons](https://demos.telerik.com/blazor-ui/contextmenu/icons)
+* [Context Menu Overview]({%slug contextmenu-overview%})

--- a/components/drawer/icons.md
+++ b/components/drawer/icons.md
@@ -10,7 +10,9 @@ position: 22
 
 # Drawer Icons
 
-You can add a [Telerik Font or SVG icon]({%slug general-information/font-icons%}) to the Drawer item by assigning an `object` to the `IconField` parameter.
+You can add [Telerik Font or SVG icons]({%slug general-information/font-icons%}) to the Drawer items. The component also supports custom icons.
+
+To use Drawer item icons, define a property in the component model class and assign the property name to the `IconField` parameter of the Drawer. The model property can hold a `FontIcon` enum, an `ISvgIcon`, or a `string` that signifies a CSS class.
 
 If the icon property name in the Drawer model is `Icon`, there is no need to set the `IconField` parameter.
 
@@ -33,8 +35,19 @@ If the icon property name in the Drawer model is `Icon`, there is no need to set
 </TelerikDrawer>
 
 <style>
+    /* Third-party icon libraries should provide these styles out-of-the-box. */
+
+    /* base styles for all custom icons */
     .my-icon {
-        /* define a background image or a custom font icon here */
+        /* Define size, position and font styles here. */
+        width: 1em;
+        height: auto;
+        font-size: 16px;
+    }
+
+    /* styles for specific custom icons */
+    .my-icon-purple {
+        /* define a background image or a font icon glyph here */
         background: purple;
     }
 </style>
@@ -50,7 +63,7 @@ If the icon property name in the Drawer model is `Icon`, there is no need to set
     {
         new DrawerItem { Text = "Current Location", Icon = FontIcon.Pin },
         new DrawerItem { Text = "Navigation", Icon = FontIcon.Globe },
-        new DrawerItem { Text = "Favorites", Icon = "my-icon" },
+        new DrawerItem { Text = "Favorites", Icon = "my-icon my-icon-purple" },
     };
 
     public class DrawerItem

--- a/components/menu/icons.md
+++ b/components/menu/icons.md
@@ -10,20 +10,34 @@ position: 15
 
 # Menu Icons
 
-You can add a [Telerik Font or SVG icon]({%slug general-information/font-icons%}) to the Menu item to illustrate its purpose by using the `IconField` parameter. The Menu also supports custom icons.
+You can add [Telerik Font or SVG icons]({%slug general-information/font-icons%}) to the Menu items. The component also supports custom icons.
 
-If the icon property in the Menu model is called `Icon`, there is no need to set the `IconField` parameter.
+To use Menu item icons, define a property in the component model class and assign the property name to the `IconField` parameter of the Menu. The model property can hold a `FontIcon` enum, an `ISvgIcon`, or a `string` that signifies a CSS class.
+
+If the icon property name in the Menu model is `Icon`, there is no need to set the `IconField` parameter.
 
 >caption How to use icons in the Telerik Menu
 
 ````CSHTML
 <TelerikMenu Data="@MenuData"
-             IconField="@(nameof(MenuItem.Icon))">
+             IconField="@(nameof(MenuItem.Icon))"
+             Orientation="@MenuOrientation.Vertical">
 </TelerikMenu>
 
 <style>
+    /* Third-party icon libraries should provide these styles out-of-the-box. */
+
+    /* base styles for all custom icons */
     .my-icon {
-        /* define a background image or a custom font icon here */
+        /* Define size, position and font styles here. */
+        width: 1em;
+        height: 1em;
+        font-size: 16px;
+    }
+
+    /* styles for specific custom icons */
+    .my-icon-purple {
+        /* define a background image or a font icon glyph here */
         background: purple;
     }
 </style>
@@ -46,10 +60,15 @@ If the icon property in the Menu model is called `Icon`, there is no need to set
                 Icon = SvgIcon.Wrench,
             },
             new MenuItem()
-             {
+            {
                 Text = "Custom Icon",
+                Icon = "my-icon my-icon-purple"
+            },
+            new MenuItem()
+            {
+                Text = "Empty Icon",
                 Icon = "my-icon"
-             }
+            }
         };
     }
 
@@ -63,4 +82,5 @@ If the icon property in the Menu model is called `Icon`, there is no need to set
 
 ## See Also
 
+* [Online Demo: Menu Icons](https://demos.telerik.com/blazor-ui/menu/icons)
 * [Menu Overview]({%slug components/menu/overview%})

--- a/components/panelbar/icons.md
+++ b/components/panelbar/icons.md
@@ -10,9 +10,11 @@ position: 15
 
 # PanelBar Icons
 
-You can add a [Telerik Font or SVG icon]({%slug general-information/font-icons%}) to the PanelBar item by assigning a `string` to the `IconField` parameter. The PanelBar also supports custom icons.
+You can add [Telerik Font or SVG icons]({%slug general-information/font-icons%}) to the PanelBar items. The component also supports custom icons.
 
-If the icon property name in the PanelBar model is `Icon`, there is no need to define the `IconField` parameter.
+To use PanelBar item icons, define a property in the component model class and assign the property name to the `IconField` parameter of the PanelBar. The model property can hold a `FontIcon` enum, an `ISvgIcon`, or a `string` that signifies a CSS class.
+
+If the icon property name in the PanelBar model is `Icon`, there is no need to set the `IconField` parameter.
 
 >caption How to use icons in the Telerik PanelBar
 
@@ -24,8 +26,19 @@ If the icon property name in the PanelBar model is `Icon`, there is no need to d
 </TelerikPanelBar>
 
 <style>
+    /* Third-party icon libraries should provide these styles out-of-the-box. */
+
+    /* base styles for all custom icons */
     .my-icon {
-        /* define a background image or a custom font icon here */
+        /* Define size, position and font styles here. */
+        width: 1em;
+        height: 1em;
+        font-size: 16px;
+    }
+
+    /* styles for specific custom icons */
+    .my-icon-purple {
+        /* define a background image or a font icon glyph here */
         background: purple;
     }
 </style>
@@ -81,7 +94,16 @@ If the icon property name in the PanelBar model is `Icon`, there is no need to d
             Text = "Custom Icon",
             ParentId = null,
             HasChildren = false,
-            Icon = "my-icon"
+            Icon = "my-icon my-icon-purple"
+        });
+
+        Items.Add(new PanelBarItem()
+        {
+            Id = 6,
+            Text = "Empty Icon",
+            ParentId = null,
+            HasChildren = false,
+            Icon = "my-icon "
         });
 
         base.OnInitialized();
@@ -101,3 +123,4 @@ If the icon property name in the PanelBar model is `Icon`, there is no need to d
 ## See Also
 
 * [PanelBar Overview]({%slug panelbar-overview%})
+* [Live Demos: PanelBar](https://demos.telerik.com/blazor-ui/panelbar/overview)

--- a/components/splitbutton/icons.md
+++ b/components/splitbutton/icons.md
@@ -23,7 +23,7 @@ The `string` parameters below exist for both `TelerikSplitButton` and `SplitButt
 
 | Parameter | Intended Usage |
 | --- | --- |
-| `Icon` | Use with the [**built-in Telerik Font and SVG icons**]({%slug general-information/font-icons%}#icons-list). |
+| `Icon` | Use with the [built-in Telerik Font and SVG icons]({%slug general-information/font-icons%}#icons-list), or with custom CSS classes. |
 
 >tip It is also possible to define **any icon or image** with custom HTML markup inside the `<SplitButtonContent>` and `<SplitButtonItem>` tags. Use this aproach for images and font icons that rely on specific rendering. One such example is the Google Material Icons library.
 
@@ -32,17 +32,31 @@ The `string` parameters below exist for both `TelerikSplitButton` and `SplitButt
 
 >caption Using icons in the Blazor SplitButton
 
-````HTML
-@* Usage of Font and SVG Icons in the SplitButton. *@
-
+````CSHTML
 <TelerikSplitButton Icon="@("sln")">
     <SplitButtonContent>Telerik Icon</SplitButtonContent>
     <SplitButtonItems>
         <SplitButtonItem Icon="@FontIcon.Table">Telerik Font Icon</SplitButtonItem>
         <SplitButtonItem Icon="@SvgIcon.Calculator">Telerik SVG Icon</SplitButtonItem>
+        <SplitButtonItem Icon="@CustomIconClass">Custom Icon</SplitButtonItem>
         <SplitButtonItem> <TelerikLoader /> Custom markup </SplitButtonItem>
     </SplitButtonItems>
 </TelerikSplitButton>
+
+<style>
+    /* Third-party icon libraries should provide these styles out-of-the-box. */
+
+    .my-icon {
+        width: 1em;
+        height: 1em;
+        font-size: 16px;
+        background: purple;
+    }
+</style>
+
+@code {
+    string CustomIconClass { get; set; } = "my-icon";
+}
 ````
 
 

--- a/components/treeview/icons.md
+++ b/components/treeview/icons.md
@@ -10,9 +10,11 @@ position: 15
 
 # TreeView Icons
 
-You can add a [Telerik Font or SVG icon]({%slug general-information/font-icons%}) to the TreeView item to illustrate its purpose by using the `IconField` parameter. The TreeView also supports custom icons.
+You can add [Telerik Font or SVG icons]({%slug general-information/font-icons%}) to the TreeView items. The component also supports custom icons.
 
-If the icon property name in the TreeView model is `Icon`, there is no need to define the `IconField` parameter.
+To use TreeView item icons, define a property in the component model class and assign the property name to the `IconField` parameter of the respective `TreeViewBinding`. The model property can hold a `FontIcon` enum, an `ISvgIcon`, or a `string` that signifies a CSS class.
+
+If the icon property name in the TreeView model is `Icon`, there is no need to set the `IconField` parameter.
 
 >caption How to use icons in the Telerik TreeView
 
@@ -24,8 +26,20 @@ If the icon property name in the TreeView model is `Icon`, there is no need to d
 </TelerikTreeView>
 
 <style>
+    /* Third-party icon libraries should provide these styles out-of-the-box. */
+
+    /* base styles for all custom icons */
     .my-icon {
-        /* define a background image or a custom font icon here */
+        /* Define size, position and font styles here. */
+        display: inline-block;
+        width: 1em;
+        height: 1em;
+        font-size: 16px;
+    }
+
+    /* styles for specific custom icons */
+    .my-icon-purple {
+        /* define a background image or a font icon glyph here */
         background: purple;
     }
 </style>
@@ -59,6 +73,14 @@ If the icon property name in the TreeView model is `Icon`, there is no need to d
         {
             Id = 3,
             Text = "Custom Icon",
+            ParentId = 1,
+            Icon = "my-icon my-icon-purple"
+        });
+
+        TreeViewData.Add(new TreeItem()
+        {
+            Id = 4,
+            Text = "Empty Icon",
             ParentId = 1,
             Icon = "my-icon"
         });


### PR DESCRIPTION
- We were missing a custom icon example for the ContextMenu.
- The custom styles needed fixing, after we stopped rendering the `k-icon` class for custom icons.