### PR TITLE
chore: grant write permissions to sync build

### DIFF
--- a/.github/workflows/sync-a11y.yml
+++ b/.github/workflows/sync-a11y.yml
@@ -13,6 +13,9 @@ jobs:
 
     runs-on: ubuntu-latest
     
+    permissions:
+      contents: write
+    
     defaults:
       run:
         working-directory: src-a11y # The resources folder name


### PR DESCRIPTION
Dependabot defaults to [read-only permissions](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#changing-github_token-permissions) and fails to push changes.