### PR TITLE
chore(upload,fileselect): fix kb example to ensure the drop hint is hidden

### DIFF
--- a/knowledge-base/fileselect-upload-hide-file-list.md
+++ b/knowledge-base/fileselect-upload-hide-file-list.md
@@ -71,8 +71,9 @@ Upload:
     /* hide selected files */
     .k-upload.button-only .k-upload-files,
     /* hide Upload status */
-    .k-upload.button-only .k-upload-status {
-
+    .k-upload.button-only .k-upload-status,
+    /* hide drop hint */
+    .k-upload.button-only .k-dropzone-hint{
         display: none;
     }
 </style>


### PR DESCRIPTION
Drop hint of the FileSelect was visible