### PR TITLE
Update samples in customize export article

### DIFF
--- a/components/grid/export/events.md
+++ b/components/grid/export/events.md
@@ -123,6 +123,8 @@ To export a hidden (the Visible attribute set to `false`) column you can manuall
                 Discontinued = x % 4 == 0,
                 FirstReleaseDate = DateTime.Now.AddDays(-x)
             }).ToList();
+      
+        SelectedItems = GridData.Take(5);
     }
 
     public class SampleData
@@ -225,6 +227,8 @@ To export a hidden (the Visible attribute set to `false`) column you can manuall
                 Discontinued = x % 4 == 0,
                 FirstReleaseDate = DateTime.Now.AddDays(-x)
             }).ToList();
+      
+        SelectedItems = GridData.Take(5);
     }
 
     public class SampleData


### PR DESCRIPTION
_Based on customer feedback_:

We are customizing the export to take only the selected items. However, there are no initially selected items. If one tries to export without selecting anything, at first this gives the impression that the export does not work as the exported file is empty.