### PR TITLE
docs(gantt): fix tooltip example

### DIFF
--- a/components/gantt/timeline/templates/tooltip.md
+++ b/components/gantt/timeline/templates/tooltip.md
@@ -45,7 +45,7 @@ Apart from that, you can add and customize any other content - for example, icon
               OnDelete="@DeleteItem">
     <TooltipTemplate>
             <h5>@(((TooltipTemplateContext)context).Title)</h5>        
-            <TelerikFontIcon Class="status" Icon="@FontIcon.Rotate"></TelerikIcon>
+            <TelerikFontIcon Class="status" Icon="@FontIcon.Rotate"></TelerikFontIcon>
             @(((TooltipTemplateContext)context).DataAttributes["percent"])% Completed                
         <br />
     </TooltipTemplate>


### PR DESCRIPTION
There was an incorrect end tag for the TelerikFontIcon

Note to external contributors: make sure to sign our Contribution License Agreement (CLA) for Blazor UI first:

https://forms.office.com/Pages/ResponsePage.aspx?id=Z2om2-DLJk2uGtBYH-A1NbWxVqugKN5DvVp8I-1AgOBURFBVSkwyMlA1TkFDVFdMNU1aM1o1UlZQOC4u
