### PR TITLE
docs(themes): Update primary color mentions

### DIFF
--- a/styling-and-themes/custom-theme.md
+++ b/styling-and-themes/custom-theme.md
@@ -71,7 +71,7 @@ To customize a Sass-based theme, create a `.scss` file and consume the theme pac
 
 1. To customize the variables that are used in the theme, change the theme before you import the theme files.
 
-        $primary: #E82C0C; // brand color
+        $kendo-color-primary: #E82C0C; // brand color
 
         @import "~@progress/kendo-theme-default/dist/all.scss";
 
@@ -132,8 +132,8 @@ For example, in the Material theme create `blue-pink-dark` swatch with the follo
 For the Default and Bootstrap themes, the swatch should look like:
 
     // Variables.
-    $primary: blue;
-    $secondary: pink;
+    $kendo-color-primary: blue;
+    $kendo-color-secondary: pink;
 
     // Import the theme file for the components you use.
     @import "../panelbar/_index.scss";

--- a/styling-and-themes/themebuilder.md
+++ b/styling-and-themes/themebuilder.md
@@ -34,7 +34,7 @@ To improve the collaboration between designers and developers, Telerik UI for Bl
    ![Color Styles in a UI Kit for Figma](./images/theme-builder-ui-kit-color-styles.png)
 
 4. Create a new project in the ThemeBuilder application. To choose the most suitable starting **Theme**, ask your designer which UI Kit was used: **Default**, **Bootstrap**, **Material**, or **Fluent**.
-5. Copy the color codes from the **Color Styles** in Figma and paste them into the ThemeBuilder color editor with the same name. For example, copy the value of the `$primary` color in Figma and paste it into the **Primary** color editor in ThemeBuilder.
+5. Copy the color codes from the **Color Styles** in Figma and paste them into the ThemeBuilder color editor with the same name. For example, copy the value of the `$primary` color in Figma and paste it into the `$kendo-color-primary` color editor in ThemeBuilder.
 
 ## See Also
 


### PR DESCRIPTION
Related to the `$primary` being renamed to `$kendo-color-primary`