### PR TITLE
docs(input validation): fix examples for MaskedTextbox and Slider

### DIFF
--- a/common-features/input-validation.md
+++ b/common-features/input-validation.md
@@ -743,7 +743,7 @@ The sliders are, effectively, numeric inputs in terms of behavior and what data 
 
 <style>
     .validation-message {
-        margin-top: 15px
+        margin-top: 1em;
     }
 </style>
 

--- a/common-features/input-validation.md
+++ b/common-features/input-validation.md
@@ -742,8 +742,8 @@ The sliders are, effectively, numeric inputs in terms of behavior and what data 
 </EditForm>
 
 <style>
-    .k-slider{
-        height: 60px
+    .validation-message{
+        margin-top: 15px
     }
 </style>
 

--- a/common-features/input-validation.md
+++ b/common-features/input-validation.md
@@ -531,7 +531,7 @@ You may want to set the [`IncludeLiterals`]({%slug maskedtextbox-mask-prompt%}#i
     <ValidationSummary />
 
     <p>
-        <TelerikFloatingLabel Text="Credit Card*:">
+        <TelerikFloatingLabel Text="Credit Card:">
             <TelerikMaskedTextBox MaskOnFocus="true" 
                                   Mask="0000-0000-0000-0000"
                                   IncludeLiterals="true"
@@ -742,7 +742,7 @@ The sliders are, effectively, numeric inputs in terms of behavior and what data 
 </EditForm>
 
 <style>
-    .validation-message{
+    .validation-message {
         margin-top: 15px
     }
 </style>

--- a/common-features/input-validation.md
+++ b/common-features/input-validation.md
@@ -531,29 +531,35 @@ You may want to set the [`IncludeLiterals`]({%slug maskedtextbox-mask-prompt%}#i
     <ValidationSummary />
 
     <p>
-        <TelerikMaskedTextBox Mask="0000-0000-0000-0000"
-                              IncludeLiterals="true"
-                              Label="Credit Card:"
-                              @bind-Value="@Payment.CreditCard">
-        </TelerikMaskedTextBox>
+        <TelerikFloatingLabel Text="Credit Card*:">
+            <TelerikMaskedTextBox MaskOnFocus="true" 
+                                  Mask="0000-0000-0000-0000"
+                                  IncludeLiterals="true"
+                                  @bind-Value="@Payment.CreditCard">
+            </TelerikMaskedTextBox>
+        </TelerikFloatingLabel>
         <ValidationMessage For="@(() => Payment.CreditCard)" />
     </p>
 
     <p>
-        <TelerikMaskedTextBox Mask="+1-000-000-0000"
-                              Label="Phone:"
-                              @bind-Value="@Payment.PhoneNumber"
-                              PromptPlaceholder="null">
-        </TelerikMaskedTextBox>
+        <TelerikFloatingLabel Text="Phone:">
+            <TelerikMaskedTextBox MaskOnFocus="true" 
+                                  Mask="+1-000-000-0000"
+                                  @bind-Value="@Payment.PhoneNumber"
+                                  PromptPlaceholder="null">
+            </TelerikMaskedTextBox>
+        </TelerikFloatingLabel>
         <ValidationMessage For="@(() => Payment.PhoneNumber)" />
     </p>
 
     <p>
-        <TelerikMaskedTextBox Mask="00000-9999"
-                              Label="ZIP:"
-                              @bind-Value="@Payment.Zip"
-                              PromptPlaceholder="null">
-        </TelerikMaskedTextBox>
+        <TelerikFloatingLabel Text="ZIP:">
+            <TelerikMaskedTextBox MaskOnFocus="true" 
+                                  Mask="00000-9999"
+                                  @bind-Value="@Payment.Zip"
+                                  PromptPlaceholder="null">
+            </TelerikMaskedTextBox>
+        </TelerikFloatingLabel>
         <ValidationMessage For="@(() => Payment.Zip)" />
     </p>
 
@@ -734,6 +740,12 @@ The sliders are, effectively, numeric inputs in terms of behavior and what data 
 
     <TelerikButton ButtonType="@ButtonType.Submit">Submit</TelerikButton>
 </EditForm>
+
+<style>
+    .k-slider{
+        height: 60px
+    }
+</style>
 
 @code{
     MyModel TheModel { get; set; } = new MyModel();


### PR DESCRIPTION
Slider-related margin fix is due to https://github.com/telerik/kendo-themes/issues/4698