### PR TITLE
docs(treeview): fix checkbox example

### DIFF
--- a/components/treeview/checkboxes/overview.md
+++ b/components/treeview/checkboxes/overview.md
@@ -199,7 +199,7 @@ Setting the `CheckChildren` boolean parameter to `true` will allow the user to s
                 var checkedItem = item as TreeItem;
                 <li>
                     <span>
-                        <TelerikFontIcon Icon="@checkedItem.Icon"></TelerikIcon>
+                        <TelerikFontIcon Icon="@checkedItem.Icon"></TelerikFontIcon>
                     </span>
                     <span>
                         @(checkedItem.Text)
@@ -340,7 +340,7 @@ Setting the `CheckParents` boolean parameter to `true` will have the following b
                 var checkedItem = item as TreeItem;
                 <li>
                     <span>
-                        <TelerikFontIcon Icon="@checkedItem.Icon"></TelerikIcon>
+                        <TelerikFontIcon Icon="@checkedItem.Icon"></TelerikFontIcon>
                     </span>
                     <span>
                         @(checkedItem.Text)
@@ -472,7 +472,7 @@ You can allow the user to click on the node itself and the TreeView will automat
                 var checkedItem = item as TreeItem;
                 <li>
                     <span>
-                        <TelerikFontIcon Icon="@checkedItem.Icon"></TelerikIcon>
+                        <TelerikFontIcon Icon="@checkedItem.Icon"></TelerikFontIcon>
                     </span>
                     <span>
                         @(checkedItem.Text)

--- a/components/treeview/checkboxes/overview.md
+++ b/components/treeview/checkboxes/overview.md
@@ -61,7 +61,7 @@ You get or set the checked nodes through the `CheckedItems` parameter of the tre
                 var checkedItem = item as TreeItem;
                 <li>
                     <span>
-                        <TelerikFontIcon Icon="@checkedItem.Icon"></TelerikIcon>
+                        <TelerikFontIcon Icon="@checkedItem.Icon"></TelerikFontIcon>
                     </span>
                     <span>
                         @(checkedItem.Text)


### PR DESCRIPTION
There was an incorrect end tag for the TelerikFontIcon

Note to external contributors: make sure to sign our Contribution License Agreement (CLA) for Blazor UI first:

https://forms.office.com/Pages/ResponsePage.aspx?id=Z2om2-DLJk2uGtBYH-A1NbWxVqugKN5DvVp8I-1AgOBURFBVSkwyMlA1TkFDVFdMNU1aM1o1UlZQOC4u
