### PR TITLE
Documentation on missing font icons in 4.6.0

### DIFF
--- a/common-features/icons.md
+++ b/common-features/icons.md
@@ -37,6 +37,8 @@ The Telerik Blazor components use built-in icons with the help of two NuGet pack
 
 >tip Unlike the `Telerik.UI.for.Blazor` package, the icon packages are available from the `nuget.org` source. Keep this in mind when using [`packageSourceMapping`](https://learn.microsoft.com/en-us/nuget/consume-packages/package-source-mapping).
 
+> The font icons are detached from the Kendo UI Themes distribution. Read the [Font Icons do not render in Telerik UI for Blazor 4.6]({%slug icon-kb-font-icons-not-rendering%}) to see how to use Font icons in your application after the 4.6.0 Telerik UI for Blazor release. 
+
 To use the icons, import one or both namespaces, for example in `_Imports.razor`:
 
 >caption Register Telerik Blazor icon namespaces

--- a/knowledge-base/font-icons-not-rendering.md
+++ b/knowledge-base/font-icons-not-rendering.md
@@ -38,28 +38,15 @@ The 7.0.0 version of the Kendo UI Themes is a dependency in Telerik UI for Blazo
 
 To keep using Font icons in your application use one of the two approaches:
 
-* Use the dedicated Telerik UI for Blazor CDN in your application:
+* Add the dedicated Telerik UI for Blazor CDN link in the _Host.cshtml or index.html (based on the hosting model) file in your application:
 
-````_Host.cshtml
-
-<link href="https://blazor.cdn.telerik.com/blazor/4.6.0/kendo-font-icons/font-icons.css" rel="stylesheet" type="text/css" />
-
+````CSHTML
 <link href="https://blazor.cdn.telerik.com/blazor/4.6.0/kendo-font-icons/font-icons.css" rel="stylesheet" type="text/css" />
 ````
-````index.html
- <link href="https://blazor.cdn.telerik.com/blazor/4.6.0/kendo-font-icons/font-icons.css" rel="stylesheet" type="text/css" />
-````
 
-* Download the [Telerik UI for Blazor package]({%slug installation/msi%}#how-to-download-the-automated-installer) and reference the static assets for the Font Icons:
+* Download the [Telerik UI for Blazor package]({%slug installation/msi%}#how-to-download-the-automated-installer) and reference the static assets for the Font Icons in the _Host.cshtml or index.html (based on the hosting model) file in your application:
 
-````_Host.cshtml
-<!-- For Trial licenses, use
-<link href="_content/Telerik.UI.for.Blazor.Trial/css/kendo-font-icons/font-icons.css" rel="stylesheet" />
--->
-
-<link href="_content/Telerik.UI.for.Blazor/css/kendo-font-icons/font-icons.css" rel="stylesheet" />
-````
-````index.html
+````CSHTML
 <!-- For Trial licenses, use
 <link href="_content/Telerik.UI.for.Blazor.Trial/css/kendo-font-icons/font-icons.css" rel="stylesheet" />
 -->

--- a/knowledge-base/font-icons-not-rendering.md
+++ b/knowledge-base/font-icons-not-rendering.md
@@ -41,7 +41,10 @@ To keep using Font icons in your application use one of the two approaches:
 * Use the dedicated Telerik UI for Blazor CDN in your application:
 
 ````_Host.cshtml
- <link href="https://blazor.cdn.telerik.com/blazor/4.6.0/kendo-font-icons/font-icons.css" rel="stylesheet" type="text/css" />
+
+<link href="https://blazor.cdn.telerik.com/blazor/4.6.0/kendo-font-icons/font-icons.css" rel="stylesheet" type="text/css" />
+
+<link href="https://blazor.cdn.telerik.com/blazor/4.6.0/kendo-font-icons/font-icons.css" rel="stylesheet" type="text/css" />
 ````
 ````index.html
  <link href="https://blazor.cdn.telerik.com/blazor/4.6.0/kendo-font-icons/font-icons.css" rel="stylesheet" type="text/css" />
@@ -50,8 +53,16 @@ To keep using Font icons in your application use one of the two approaches:
 * Download the [Telerik UI for Blazor package]({%slug installation/msi%}#how-to-download-the-automated-installer) and reference the static assets for the Font Icons:
 
 ````_Host.cshtml
+<!-- For Trial licenses, use
+<link href="_content/Telerik.UI.for.Blazor.Trial/css/kendo-font-icons/font-icons.css" rel="stylesheet" />
+-->
+
 <link href="_content/Telerik.UI.for.Blazor/css/kendo-font-icons/font-icons.css" rel="stylesheet" />
 ````
 ````index.html
+<!-- For Trial licenses, use
+<link href="_content/Telerik.UI.for.Blazor.Trial/css/kendo-font-icons/font-icons.css" rel="stylesheet" />
+-->
+
 <link href="_content/Telerik.UI.for.Blazor/css/kendo-font-icons/font-icons.css" rel="stylesheet" />
 ````

--- a/knowledge-base/font-icons-not-rendering.md
+++ b/knowledge-base/font-icons-not-rendering.md
@@ -38,13 +38,13 @@ The 7.0.0 version of the Kendo UI Themes is a dependency in Telerik UI for Blazo
 
 To keep using Font icons in your application use one of the two approaches:
 
-* Add the dedicated Telerik UI for Blazor CDN link in the _Host.cshtml or index.html (based on the hosting model) file in your application:
+* Add the dedicated Telerik UI for Blazor CDN link in the `_Host.cshtml` or `index.html` (based on the hosting model) file in your application:
 
 ````CSHTML
 <link href="https://blazor.cdn.telerik.com/blazor/4.6.0/kendo-font-icons/font-icons.css" rel="stylesheet" type="text/css" />
 ````
 
-* Download the [Telerik UI for Blazor package]({%slug installation/msi%}#how-to-download-the-automated-installer) and reference the static assets for the Font Icons in the _Host.cshtml or index.html (based on the hosting model) file in your application:
+* Download the [Telerik UI for Blazor package]({%slug installation/msi%}#how-to-download-the-automated-installer) and reference the static assets for the Font Icons in the `_Host.cshtml` or `index.html` (based on the hosting model) file in your application:
 
 ````CSHTML
 <!-- For Trial licenses, use

--- a/knowledge-base/font-icons-not-rendering.md
+++ b/knowledge-base/font-icons-not-rendering.md
@@ -2,7 +2,7 @@
 title: Font Icons do not render in Telerik UI for Blazor 4.6
 description: Font Icons do not render in Telerik UI for Blazor 4.6
 type: troubleshooting
-page_title: Font Icons do not render in Telerik UI for Blazor 4.6
+page_title: Font Icons do not Render in Telerik UI for Blazor 4.6.0
 slug: icon-kb-font-icons-not-rendering
 position: 
 tags: telerik, blazor, fonticon, font, icon

--- a/knowledge-base/font-icons-not-rendering.md
+++ b/knowledge-base/font-icons-not-rendering.md
@@ -15,7 +15,7 @@ res_type: kb
     <tbody>
         <tr>
             <td>Product Version</td>
-            <td>4.6</td>
+            <td>4.6.0</td>
         </tr>
         <tr>
             <td>Product</td>

--- a/knowledge-base/font-icons-not-rendering.md
+++ b/knowledge-base/font-icons-not-rendering.md
@@ -1,0 +1,57 @@
+---
+title: Font Icons do not render in Telerik UI for Blazor 4.6
+description: Font Icons do not render in Telerik UI for Blazor 4.6
+type: troubleshooting
+page_title: Font Icons do not render in Telerik UI for Blazor 4.6
+slug: icon-kb-font-icons-not-rendering
+position: 
+tags: telerik, blazor, fonticon, font, icon
+res_type: kb
+---
+
+## Environment
+
+<table>
+    <tbody>
+        <tr>
+            <td>Product Version</td>
+            <td>4.6</td>
+        </tr>
+        <tr>
+            <td>Product</td>
+            <td>Progress® Telerik® UI for Blazor</td>
+        </tr>
+    </tbody>
+</table>
+
+## Description
+
+After upgrading to the 4.6.0 version of the Telerik UI for Blazor suite the Font Icons in my application are not longer showing (rendering). 
+
+## Possible Cause
+
+Each Telerik UI for Blazor version has a dependency on a specific version of the Kendo UI Themes. As part of the [7.0.0 version of the Kendo UI Themes](https://github.com/telerik/kendo-themes/blob/develop/CHANGELOG.md#breaking-changes), the Font Icons were detached from the themes distribution.
+
+The 7.0.0 version of the Kendo UI Themes is a dependency in Telerik UI for Blazor 4.6.0; thus, the font icons are missing.
+
+## Solution
+
+To keep using Font icons in your application use one of the two approaches:
+
+* Use the dedicated Telerik UI for Blazor CDN in your application:
+
+````_Host.cshtml
+ <link href="https://blazor.cdn.telerik.com/blazor/4.6.0/kendo-font-icons/font-icons.css" rel="stylesheet" type="text/css" />
+````
+````index.html
+ <link href="https://blazor.cdn.telerik.com/blazor/4.6.0/kendo-font-icons/font-icons.css" rel="stylesheet" type="text/css" />
+````
+
+* Download the [Telerik UI for Blazor package]({%slug installation/msi%}#how-to-download-the-automated-installer) and reference the static assets for the Font Icons:
+
+````_Host.cshtml
+<link href="_content/Telerik.UI.for.Blazor/css/kendo-font-icons/font-icons.css" rel="stylesheet" />
+````
+````index.html
+<link href="_content/Telerik.UI.for.Blazor/css/kendo-font-icons/font-icons.css" rel="stylesheet" />
+````

--- a/knowledge-base/font-icons-not-rendering.md
+++ b/knowledge-base/font-icons-not-rendering.md
@@ -1,5 +1,5 @@
 ---
-title: Font Icons do not render in Telerik UI for Blazor 4.6
+title: Font Icons do not Render in Telerik UI for Blazor 4.6.0
 description: Font Icons do not render in Telerik UI for Blazor 4.6
 type: troubleshooting
 page_title: Font Icons do not Render in Telerik UI for Blazor 4.6.0


### PR DESCRIPTION
Related to: https://github.com/telerik/blazor/issues/7485