### PR TITLE
docs(tooltip): fix tooltip example

### DIFF
--- a/components/tooltip/overview.md
+++ b/components/tooltip/overview.md
@@ -28,12 +28,12 @@ The Tooltip will automatically display the value of `title` and `alt` attributes
 <div style="padding: 5em;">
     Hover the button ...
 
-    <TelerikButton Icon="@FontIcon.Eye" Title="Hello world!" Class="tooltip-target" />
+    <TelerikButton Icon="@SvgIcon.Eye" Title="Hello world!" Class="tooltip-target" />
 
     ... and the question mark:
 
     <span title="I am a Telerik Blazor Tooltip." class="tooltip-target">
-        <TelerikFontIcon Icon="@FontIcon.QuestionCircle" />
+        <TelerikSvgIcon Icon="@SvgIcon.QuestionCircle" />
     </span>
 </div>
 ````


### PR DESCRIPTION
FontIcons did not render. 
