### PR TITLE
docs(grid): fix grid knowledge base example

### DIFF
--- a/knowledge-base/grid-conditional-cell-background.md
+++ b/knowledge-base/grid-conditional-cell-background.md
@@ -198,7 +198,7 @@ If you want to change the default row and alternating row backgrounds to match y
         background-color: red;
     }
 
-        .custom-row-colors .k-grid-table .k-master-row.k-master-row:hover {
+        .custom-row-colors .k-grid-table .k-table-row.k-master-row:hover {
             background-color: pink;
         }
 

--- a/knowledge-base/grid-conditional-cell-background.md
+++ b/knowledge-base/grid-conditional-cell-background.md
@@ -198,7 +198,7 @@ If you want to change the default row and alternating row backgrounds to match y
         background-color: red;
     }
 
-        .custom-row-colors .k-grid-table .k-master-row:hover {
+        .custom-row-colors .k-grid-table .k-master-row.k-master-row:hover {
             background-color: pink;
         }
 


### PR DESCRIPTION
One of the custom CSS selectors did not work because it had lower specificity than one of our CSS selectors.  