### PR TITLE
docs(grid, scheduler): add read-only properties documentation

### DIFF
--- a/components/grid/editing/overview.md
+++ b/components/grid/editing/overview.md
@@ -417,6 +417,7 @@ There are a few considerations to keep in mind with the CUD operations of the gr
     * Another case when you may need to insert items through the grid state is when you use [OnRead with grouping]({%slug components/grid/manual-operations%}#grouping-with-onread). In such cases the Grid is bound to an `object`, not to a particular model. As a result, it can't create new items for you and errors may be thrown. A workaround might be [invoking Edit/Insert through the grid state]({%slug grid-state%}#initiate-editing-or-inserting-of-an-item) and creating the object with your own code.
 
 * While editing, the Grid creates a **copy of your original object** which has a **different reference**. You receive that copy in the `OnUpdate` event handler. The `OnEdit` event receives the original item from the pristine `Data` collection, because it is a cancellable event and fires before the grid logic creates the copy. The built-in editors and [editor templates]({%slug grid-templates-editor%}) receive the copy for their `context` that the grid will create after `OnEdit`.
+    * For the Grid to successfully create a copy of the original object, all properties should have a getter setter and not be read-only. Otherwise, editing may stop working.
 
 * If you want to pre-populate values to the user, see the [Setting default values in new row]({%slug grid-kb-default-value-for-new-row%}) KnowledgeBase article.
 

--- a/components/grid/editing/overview.md
+++ b/components/grid/editing/overview.md
@@ -417,7 +417,7 @@ There are a few considerations to keep in mind with the CUD operations of the gr
     * Another case when you may need to insert items through the grid state is when you use [OnRead with grouping]({%slug components/grid/manual-operations%}#grouping-with-onread). In such cases the Grid is bound to an `object`, not to a particular model. As a result, it can't create new items for you and errors may be thrown. A workaround might be [invoking Edit/Insert through the grid state]({%slug grid-state%}#initiate-editing-or-inserting-of-an-item) and creating the object with your own code.
 
 * While editing, the Grid creates a **copy of your original object** which has a **different reference**. You receive that copy in the `OnUpdate` event handler. The `OnEdit` event receives the original item from the pristine `Data` collection, because it is a cancellable event and fires before the grid logic creates the copy. The built-in editors and [editor templates]({%slug grid-templates-editor%}) receive the copy for their `context` that the grid will create after `OnEdit`.
-    * For the Grid to successfully create a copy of the original object, all properties must have both a getter and setter and must not be read-only. Otherwise, editing may stop working.
+    * For the Grid to successfully create a copy of the original object, all properties must have а setter and must not be `readonly`. Otherwise, editing may stop working.
 
 * If you want to pre-populate values to the user, see the [Setting default values in new row]({%slug grid-kb-default-value-for-new-row%}) KnowledgeBase article.
 

--- a/components/grid/editing/overview.md
+++ b/components/grid/editing/overview.md
@@ -417,7 +417,7 @@ There are a few considerations to keep in mind with the CUD operations of the gr
     * Another case when you may need to insert items through the grid state is when you use [OnRead with grouping]({%slug components/grid/manual-operations%}#grouping-with-onread). In such cases the Grid is bound to an `object`, not to a particular model. As a result, it can't create new items for you and errors may be thrown. A workaround might be [invoking Edit/Insert through the grid state]({%slug grid-state%}#initiate-editing-or-inserting-of-an-item) and creating the object with your own code.
 
 * While editing, the Grid creates a **copy of your original object** which has a **different reference**. You receive that copy in the `OnUpdate` event handler. The `OnEdit` event receives the original item from the pristine `Data` collection, because it is a cancellable event and fires before the grid logic creates the copy. The built-in editors and [editor templates]({%slug grid-templates-editor%}) receive the copy for their `context` that the grid will create after `OnEdit`.
-    * For the Grid to successfully create a copy of the original object, all properties should have a getter setter and not be read-only. Otherwise, editing may stop working.
+    * For the Grid to successfully create a copy of the original object, all properties must have both a getter and setter and must not be read-only. Otherwise, editing may stop working.
 
 * If you want to pre-populate values to the user, see the [Setting default values in new row]({%slug grid-kb-default-value-for-new-row%}) KnowledgeBase article.
 

--- a/components/scheduler/editing/edit-appointments.md
+++ b/components/scheduler/editing/edit-appointments.md
@@ -307,7 +307,7 @@ The example below shows the signature of the event handlers so you can copy the 
 
 ## Notes 
 
-* While editing, the Scheduler creates a copy of your original object, which has a different reference. You receive that copy in the `OnUpdate` event handler. The `OnEdit` event receives the original item from the pristine `Data` collection because it is a cancellable event and fires before the Scheduler logic creates the copy.
+* While editing, the Scheduler creates a copy of your original object. The copy has a different reference than the original object. You receive that copy in the `OnUpdate` event handler. The `OnEdit` event receives the original item from the pristine `Data` collection because it is a cancellable event and fires before the Scheduler logic creates the copy.
     * For the Scheduler to successfully create a copy of the original object, all properties must have both a getter and setter and must not be read-only. Otherwise, editing may stop working.
 
 

--- a/components/scheduler/editing/edit-appointments.md
+++ b/components/scheduler/editing/edit-appointments.md
@@ -308,7 +308,7 @@ The example below shows the signature of the event handlers so you can copy the 
 ## Notes 
 
 * While editing, the Scheduler creates a copy of your original object. The copy has a different reference than the original object. You receive that copy in the `OnUpdate` event handler. The `OnEdit` event receives the original item from the pristine `Data` collection because it is a cancellable event and fires before the Scheduler logic creates the copy.
-    * For the Scheduler to successfully create a copy of the original object, all properties must have both a getter and setter and must not be read-only. Otherwise, editing may stop working.
+    * For the Scheduler to successfully create a copy of the original object, all properties must have а setter and must not be `readonly`. Otherwise, editing may stop working.
 
 
 ## See Also

--- a/components/scheduler/editing/edit-appointments.md
+++ b/components/scheduler/editing/edit-appointments.md
@@ -307,8 +307,8 @@ The example below shows the signature of the event handlers so you can copy the 
 
 ## Notes 
 
-* While editing, the Scheduler creates a **copy of your original object** which has a **different reference**. You receive that copy in the `OnUpdate` event handler. The `OnEdit` event receives the original item from the pristine `Data` collection, because it is a cancellable event and fires before the Scheduler logic creates the copy.
-    * For the Scheduler to successfully create a copy of the original object, all properties should have a getter setter and not be read-only. Otherwise, editing may stop working.
+* While editing, the Scheduler creates a copy of your original object, which has a different reference. You receive that copy in the `OnUpdate` event handler. The `OnEdit` event receives the original item from the pristine `Data` collection because it is a cancellable event and fires before the Scheduler logic creates the copy.
+    * For the Scheduler to successfully create a copy of the original object, all properties must have both a getter and setter and must not be read-only. Otherwise, editing may stop working.
 
 
 ## See Also

--- a/components/scheduler/editing/edit-appointments.md
+++ b/components/scheduler/editing/edit-appointments.md
@@ -305,6 +305,11 @@ The example below shows the signature of the event handlers so you can copy the 
 }
 ````
 
+## Notes 
+
+* While editing, the Scheduler creates a **copy of your original object** which has a **different reference**. You receive that copy in the `OnUpdate` event handler. The `OnEdit` event receives the original item from the pristine `Data` collection, because it is a cancellable event and fires before the Scheduler logic creates the copy.
+    * For the Scheduler to successfully create a copy of the original object, all properties should have a getter setter and not be read-only. Otherwise, editing may stop working.
+
 
 ## See Also
 


### PR DESCRIPTION
Related to: [#7373](https://github.com/telerik/blazor/issues/7373)
