### PR TITLE
docs(common): Fix incorrect mentioning of primitive types

### DIFF
--- a/_contentTemplates/common/observable-data.md
+++ b/_contentTemplates/common/observable-data.md
@@ -19,9 +19,9 @@ The Observable collections fire the `CollectionChanged` event only when their `A
 #refresh-data
 In Blazor, the framework will fire the `OnParametersSet` event of a child component (which is how child components can react to outside changes) only when it can detect a change in the object it receives through the corresponding parameter (like `Data` for the data sources of Telerik components). This detection works as follows:
 
-  * For primitive types (such as numbers, strings), this happens when their value changes.
+  * For strings and [value types](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-types), this happens when their value changes.
 
-  * For complex types (such as data collections like `List`, or any `IEnumerable`, and application-specific models/objects), this happens when the object reference changes.
+  * For [reference types](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/reference-types) (such as data collections like `List`, or any `IEnumerable`, and application-specific objects), this happens when the object reference changes.
 
     Thus, you would usually need to create a `new` reference for the view-model field (such as `TreeViewData = new List<MyTreeViewItem>(theUpdatedDataCollection);`) when you want the component to update.
 #end

--- a/common-features/data-binding/overview.md
+++ b/common-features/data-binding/overview.md
@@ -105,7 +105,7 @@ The [example below](#example) demonstrates the second and third option. Also che
 
 The Blazor framework will fire `OnParametersSet` of a component only when it detects a change in the component's parameter values (such as `Data`). The change detection works like this:
 
-* For strings and [value types](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-types) (numbers, dates, booleans), the detection occurs when the **value** changes.
+* For strings and [value types](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-types) (numbers, dates, booleans), the detection occurs when the value changes.
 * For [reference types](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/reference-types) (such as `IEnumerable` and any application-specific objects), the detection occurs when the **object reference** changes.
 
 Thus, you will usually need to create a new reference for `Data` value in order to refresh the component.

--- a/common-features/data-binding/overview.md
+++ b/common-features/data-binding/overview.md
@@ -105,8 +105,8 @@ The [example below](#example) demonstrates the second and third option. Also che
 
 The Blazor framework will fire `OnParametersSet` of a component only when it detects a change in the component's parameter values (such as `Data`). The change detection works like this:
 
-* For primitive types (numbers, strings, booleans), the detection occurs happens when the **value** changes.
-* For complex types (such as `IEnumerable` and any application-specific objects), the detection occurs when the **object reference** changes.
+* For strings and [value types](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-types) (numbers, dates, booleans), the detection occurs when the **value** changes.
+* For [reference types](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/reference-types) (such as `IEnumerable` and any application-specific objects), the detection occurs when the **object reference** changes.
 
 Thus, you will usually need to create a new reference for `Data` value in order to refresh the component.
 

--- a/common-features/data-binding/overview.md
+++ b/common-features/data-binding/overview.md
@@ -106,7 +106,7 @@ The [example below](#example) demonstrates the second and third option. Also che
 The Blazor framework will fire `OnParametersSet` of a component only when it detects a change in the component's parameter values (such as `Data`). The change detection works like this:
 
 * For strings and [value types](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-types) (numbers, dates, booleans), the detection occurs when the value changes.
-* For [reference types](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/reference-types) (such as `IEnumerable` and any application-specific objects), the detection occurs when the **object reference** changes.
+* For [reference types](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/reference-types) (such as `IEnumerable` and any application-specific objects), the detection occurs when the object reference changes.
 
 Thus, you will usually need to create a new reference for `Data` value in order to refresh the component.
 

--- a/common-features/input-validation.md
+++ b/common-features/input-validation.md
@@ -294,7 +294,7 @@ The ComboBox works with the `Value` of the selected item (through its `ValueFiel
 @* This Using is for the model class attributes only *@
 @* The Id parameter is not mandatory for validation, ut just shows better forms integration *@
 
-@*You can still use a full model, primitive types are used for brevity here*@
+@*You can still use a full model. Strings are used for brevity here*@
 
 <EditForm Model="@person" OnValidSubmit="@HandleValidSubmit">
     <DataAnnotationsValidator />

--- a/components/autocomplete/data-bind.md
+++ b/components/autocomplete/data-bind.md
@@ -16,14 +16,14 @@ This article explains the different ways to provide data to an AutoComplete comp
 
 There are two key ways to bind data:
 
-* [Primitive Type](#primitive-type)
+* [Strings and Value Types](#strings-and-value-types)
 * [Model](#bind-to-a-model)
 
 There are also some [considerations](#considerations) to keep in mind.
 
 @[template](/_contentTemplates/common/get-model-from-dropdowns.md#get-model-from-dropdowns)
 
-## Primitive Types
+## Strings and Value Types
 
 You can data bind the AutoComplete to a simple collection of `string` data. When you have a concrete list of options for the user to choose from, their string representation is often suitable for display and you do not need special models.
 
@@ -37,9 +37,9 @@ To bind the AutoComplete, you need to:
 ````CSHTML
 @*Bind to an IEnumerable<string>*@
 
-User input 1: @TheValue
+User input 1: @FirstValue
 <br />
-<TelerikAutoComplete Data="@Suggestions" @bind-Value="@TheValue" />
+<TelerikAutoComplete Data="@Suggestions" @bind-Value="@FirstValue" />
 
 <br />
 User input 2: @SecondValue
@@ -47,11 +47,11 @@ User input 2: @SecondValue
 <TelerikAutoComplete Data="@ArraySuggestions" @bind-Value="@SecondValue" />
 
 @code{
-    string TheValue { get; set; }
-    List<string> Suggestions { get; set; } = new List<string> { "first", "second", "third" };
+    private string FirstValue { get; set; }
+    private List<string> Suggestions { get; set; } = new List<string> { "first", "second", "third" };
 
-    string SecondValue { get; set; }
-    string[] ArraySuggestions = new string[] { "one", "two", "three" };
+    private string SecondValue { get; set; }
+    private string[] ArraySuggestions = new string[] { "one", "two", "three" };
 }
 ````
 
@@ -68,14 +68,16 @@ To bind the AutoComplete to a model:
 >caption Data binding an AutoComplete to a model
 
 ````CSHTML
-@TheValue
+@AutoComplete
 <br />
-<TelerikAutoComplete Data="@Suggestions" ValueField="@( nameof(SuggestionsModel.Suggestion) )" @bind-Value="@TheValue" />
+<TelerikAutoComplete Data="@Suggestions"
+                     @bind-Value="@AutoComplete"
+                     ValueField="@( nameof(SuggestionsModel.Suggestion) )" />
 
 @code{
-    string TheValue { get; set; }
+    private string AutoComplete { get; set; }
 
-    List<SuggestionsModel> Suggestions { get; set; } = new List<SuggestionsModel>
+    private List<SuggestionsModel> Suggestions { get; set; } = new List<SuggestionsModel>
     {
         new SuggestionsModel { Suggestion = "first", SomeOtherField = 1 },
         new SuggestionsModel { Suggestion = "second", SomeOtherField = 2 },
@@ -94,32 +96,38 @@ To bind the AutoComplete to a model:
 
 ### Reference
 
-The AutoComplete component is generic and its type depends on the type of the model you provide as its `Data` collection.
+The AutoComplete is a generic component and its type depends on the type of its `Data` and `Value`.
 
 <div class="skip-repl"></div>
-````Primitive
-@*Reference type when binding to primitive collections*@
+````String
+@*Reference when binding to a string collection*@
 
-<TelerikAutoComplete @ref="@AutoCompleteRefWithPrimitiveData" Data="@Suggestions" @bind-Value="@TheValue" />
+<TelerikAutoComplete @ref="@AutoCompleteRef"
+                     Data="@Suggestions"
+                     @bind-Value="@AutoCompleteValue" />
 
 @code{
-    TelerikAutoComplete<string> AutoCompleteRefWithPrimitiveData { get; set; }
+    private TelerikAutoComplete<string> AutoCompleteRef { get; set; }
 
-    string TheValue { get; set; }
-    List<string> Suggestions { get; set; } = new List<string> { "first", "second", "third" };
+    private string AutoCompleteValue { get; set; }
+
+    private List<string> Suggestions { get; set; } = new List<string> { "first", "second", "third" };
 }
 ````
 ````Model
-@*Reference when binding to model collections*@
+@*Reference when binding to a model collection*@
 
-<TelerikAutoComplete @ref="@AutoCompleteRefWithModel" Data="@Suggestions" ValueField="@( nameof(SuggestionsModel.Suggestion) )" @bind-Value="@TheValue" />
+<TelerikAutoComplete @ref="@AutoCompleteRef"
+                     Data="@Suggestions" 
+                     @bind-Value="@AutoCompleteValue"
+                     ValueField="@( nameof(SuggestionsModel.Suggestion) )" />
 
 @code{
-    TelerikAutoComplete<SuggestionsModel> AutoCompleteRefWithModel { get; set; }
+    private TelerikAutoComplete<SuggestionsModel> AutoCompleteRef { get; set; }
 
-    string TheValue { get; set; }
+    private string AutoCompleteValue { get; set; }
 
-    List<SuggestionsModel> Suggestions { get; set; } = new List<SuggestionsModel>
+    private List<SuggestionsModel> Suggestions { get; set; } = new List<SuggestionsModel>
     {
         new SuggestionsModel { Suggestion = "first", SomeOtherField = 1 },
         new SuggestionsModel { Suggestion = "second", SomeOtherField = 2 },
@@ -133,7 +141,6 @@ The AutoComplete component is generic and its type depends on the type of the mo
     }
 }
 ````
-
 
 ### Missing Data
 
@@ -151,8 +158,7 @@ The AutoComplete is, essentially, a textbox. This means that its `Value` is alwa
 }
 ````
 
-
 ## See Also
 
-  * [AutoComplete Overview]({%slug autocomplete-overview%})
-  * [Live Demo: AutoComplete](https://demos.telerik.com/blazor-ui/autocomplete/overview)
+* [AutoComplete Overview]({%slug autocomplete-overview%})
+* [Live Demo: AutoComplete](https://demos.telerik.com/blazor-ui/autocomplete/overview)

--- a/components/autocomplete/overview.md
+++ b/components/autocomplete/overview.md
@@ -15,28 +15,27 @@ The <a href="https://www.telerik.com/blazor-ui/autocomplete" target="_blank">Bla
 ## Creating AutoComplete
 
 1. Use the `TelerikAutoComplete` tag to add the component to your razor page.
-
 1. Populate the `Data` property with the collection of items that you want to appear in the dropdown.
-
 1. [Bind the value of the component]({%slug get-started-value-vs-data-binding %}#value-binding) to the same type as the member of the `ValueField` parameter.
-
 1. (Optional) Enable features like placeholder text and [clear button](#clear-button).
 
->caption AutoComplete with two-way value binding and data binding to a primitive type
+>caption AutoComplete with two-way value binding and data binding to collection of strings
 
 ````CSHTML
-@* AutoComplete with two-way value binding and data binding to a primitive type *@
+@* AutoComplete with two-way value binding and data binding to a collection of strings *@
 
-User input: @TheValue
+User input: @AutoCompleteValue
 <br />
-<TelerikAutoComplete Data="@Suggestions" @bind-Value="@TheValue"
-    Placeholder="Enter your role (can be free text)" ClearButton="true" />
+<TelerikAutoComplete Data="@Suggestions"
+                     @bind-Value="@AutoComplete"
+                     Placeholder="Enter your role (can be free text)"
+                     ClearButton="true" />
 
 @code{
     //Current value is null (no item is selected) which allows the Placeholder to be displayed.
-    string TheValue { get; set; }
+    private string AutoComplete { get; set; }
 
-    List<string> Suggestions { get; set; } = new List<string> {
+    private List<string> Suggestions { get; set; } = new List<string> {
         "Manager", "Developer", "QA", "Technical Writer", "Support Engineer", "Sales Agent", "Architect", "Designer"
     };
 }

--- a/components/combobox/data-bind.md
+++ b/components/combobox/data-bind.md
@@ -16,42 +16,41 @@ This article explains the different ways to provide data to a ComboBox component
 
 There are two key ways to bind data:
 
-* [Primitive Types](#primitive-types)
+* [Strings and Value Types](#strings-and-value-types)
 * [Model](#bind-to-a-model)
 
-and some considerations you may find useful, such as showing the `Placeholder` when the value is out of the data source range:
+There are also some considerations you may find useful, such as showing the `Placeholder` when the value is out of the data source range:
 
 * [Considerations](#considerations)
 	* [Value Out of Range](#value-out-of-range)
 	* [Component Reference](#component-reference)
 	* [Missing Value or Data](#missing-value-or-data)
 
-## Primitive Types
+## Strings and Value Types
 
-You can data bind the ComboBox to a simple collection of data. When you have a concrete list of options for the user to choose from, their string representation is often suitable for display and you do not need special models. 
+You can data bind the ComboBox to a collection of `string` or [value type](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-types) data (such as `int`, `decimal`, `bool`, `Guid`, and `Enum`). When you have a concrete list of options for the user to choose from, their string representation is often suitable for display and you do not need special models. 
 
-To bind the combobox to a primitive type (like `int`, `string`, `double`), you need to
+To bind the combobox to string or value type data, you need to:
 
 1. provide an `IEnumerable<TItem>` of the desired type to its `Data` property
 1. set a corresponding `Value`. If the `Value` is `null`, it will be populated with the first item from the data source.
 
->caption Data binding a ComboBox to a primitive type
+>caption Data binding a ComboBox to string data
 
 ````CSHTML
-@*Bind to a List of a primitive type (string, int,...)*@
-
-<TelerikComboBox Data="@MyList" @bind-Value="MyItem">
+<TelerikComboBox Data="@ComboBoxData"
+                 @bind-Value="ComboBoxValue">
 </TelerikComboBox>
 
 @code {
-    protected List<string> MyList = new List<string>() { "first", "second", "third" };
+    private List<string> ComboBoxData = new List<string>() { "first", "second", "third" };
 
-    protected string MyItem { get; set; }
+    private string ComboBoxValue { get; set; } = string.Empty;
 
     //Define a preselected value when the component initializes
     protected override void OnInitialized()
     {
-        MyItem = "second";
+        ComboBoxValue = "second";
     }
 }
 ````
@@ -66,34 +65,39 @@ To bind the ComboBox to a model:
 1. Set the `TextField` and `ValueField` parameters to point to the corresponding property names of the model.
 1. Set the `Value` property to the initial value of the component (optional).
 
-> The `TextField` and `ValueField` parameters must point to model properties, which are of **primitive** type (`int`, `string`, etc.). The `Value` and `ValueField` types must match and also be primitive.
+> The `TextField` and `ValueField` parameters must point to `string` or [value type](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-types) properties. The `Value` parameter type must match the type of the `ValueField` property.
 
 >caption Data binding a ComboBox to a model
 
 ````CSHTML
-@selectedValue
-
-<TelerikComboBox Data="@myDdlData" TextField="MyTextField" ValueField="MyValueField" @bind-Value="selectedValue">
+@ComboBoxValue
+<br />
+<TelerikComboBox Data="@ComboBoxData"
+                 @bind-Value="ComboBoxValue"
+                 TextField="MyTextField"
+                 ValueField="MyValueField"
+                 Width="200px">
 </TelerikComboBox>
 
 @code {
-    //in a real case, the model is usually in a separate file
-    //the model type and value field type must be provided to the dropdpownlist
-    public class MyDdlModel
-    {
-        public int MyValueField { get; set; }
-        public string MyTextField { get; set; }
-    }
+    private IEnumerable<ComboBoxItem> ComboBoxData = Enumerable.Range(1, 20)
+        .Select(x => new ComboBoxItem { MyTextField = $"Item {x}", MyValueField = x });
 
-    int selectedValue { get; set; }
+    private int ComboBoxValue { get; set; }
 
     //Define a preselected value when the component initializes
     protected override void OnInitialized()
     {
-        selectedValue = 3;
+        ComboBoxValue = 3;
     }
 
-    IEnumerable<MyDdlModel> myDdlData = Enumerable.Range(1, 20).Select(x => new MyDdlModel { MyTextField = "item " + x, MyValueField = x });
+    //In a real case, the model is usually in a separate file.
+    //The model type and value field type must be provided to the ComboBox
+    public class ComboBoxItem
+    {
+        public int MyValueField { get; set; }
+        public string MyTextField { get; set; } = string.Empty;
+    }
 }
 ````
 
@@ -117,76 +121,94 @@ When `AllowCustom="true"`, what the user types in the input will be set to the `
 
 ### Component Reference
 
-The ComboBox is a generic component and its type comes from the model it is bound to and from the value field type. When bound to a primitive type, the reference is of that primitive type only.
+The ComboBox is a generic component and its type depends on the type of its `Data` and `Value`.
 
 <div class="skip-repl"></div>
-````Primitive
-@*Reference type when binding to primitive values*@
+````String
+@*ComboBox reference when binding to a string collection*@
 
-<TelerikComboBox @ref="myComboRef" Data="@MyList" Value="@initialValue">
+<TelerikComboBox @ref="ComboBoxRef"
+                 Data="@ComboBoxData"
+                 Value="@ComboBoxValue">
 </TelerikComboBox>
 
 @code {
-    //the type of the generic component is determined by the type of the model you pass to it, and the type of its value field
-    Telerik.Blazor.Components.TelerikComboBox<string, string> myComboRef;
+    private TelerikComboBox<string, string>? ComboBoxRef { get; set; }
 
-    protected List<string> MyList = new List<string>() { "first", "second", "third" };
+    private List<string> ComboBoxData = new List<string>() { "first", "second", "third" };
 
-    string initialValue { get; set; }
+    private string ComboBoxValue { get; set; } = string.Empty;
 
-    //Define a preselected value when the component initializes
     protected override void OnInitialized()
     {
-        initialValue = "third";
+        ComboBoxValue = "third";
     }
 }
 ````
 ````Model
-@*Reference when binding to model collections*@
+@*ComboBox reference when binding to a model collection*@
 
-<TelerikComboBox @ref="@myComboRef" Data="@myComboData" TextField="MyTextField" ValueField="MyValueField" Value="3">
+<TelerikComboBox @ref="@ComboBoxRef"
+                 Data="@ComboBoxData"
+                 @bind-Value="@ComboBoxValue"
+                 TextField="@nameof(ComboBoxItem.MyTextField)"
+                 ValueField="@nameof(ComboBoxItem.MyValueField)">
 </TelerikComboBox>
+
 @code {
-    //the type of the generic component is determined by the type of the model you pass to it, and the type of its value field
-    Telerik.Blazor.Components.TelerikComboBox<MyDdlModel, int> myComboRef;
+    private TelerikComboBox<ComboBoxItem, int>? ComboBoxRef { get; set; }
 
-    IEnumerable<MyDdlModel> myComboData = Enumerable.Range(1, 20).Select(x => new MyDdlModel { MyTextField = "item " + x, MyValueField = x });
+    private IEnumerable<ComboBoxItem> ComboBoxData = Enumerable.Range(1, 20)
+        .Select(x => new ComboBoxItem { MyTextField = "Item " + x, MyValueField = x });
 
-    public class MyDdlModel
+    private int ComboBoxValue { get; set; }
+
+    protected override void OnInitialized()
+    {
+        ComboBoxValue = 3;
+    }
+
+    public class ComboBoxItem
     {
         public int MyValueField { get; set; }
-        public string MyTextField { get; set; }
+        public string MyTextField { get; set; } = string.Empty;
     }
 }
 ````
 
 ### Missing Value or Data
 
- In case you cannot provide either of a `Value`, or `Data`, or both when the component initializes, you need to set the corresponding type properties to the `TItem` and `TValue` properties as shown below.
+In case you cannot provide strongly-typed `Value` or `Data` at compile time, you need to set the corresponding type properties to the `TItem` and `TValue` properties as shown below.
 
 >caption ComboBox configuration if you cannot provide Value or Data
 
 ````CSHTML
 @*How to declare the combobox if no Value or Data are provided*@
 
-<TelerikComboBox Data="@myComboData" TextField="MyTextField" ValueField="MyValueField" TValue="int" TItem="MyDdlModel">
+<TelerikComboBox @ref="@ComboBoxRef"
+                 Data="@ComboBoxData"
+                 TItem="@ComboBoxItem"
+                 TValue="@int"
+                 TextField="@nameof(ComboBoxItem.MyTextField)"
+                 ValueField="@nameof(ComboBoxItem.MyValueField)">
 </TelerikComboBox>
 
 @code {
-    public class MyDdlModel //TItem matches the type of the model
+    private TelerikComboBox<ComboBoxItem, int>? ComboBoxRef { get; set; }
+
+    private IEnumerable<ComboBoxItem> ComboBoxData = Enumerable.Range(1, 20)
+        .Select(x => new ComboBoxItem { MyTextField = "Item " + x, MyValueField = x });
+
+    public class ComboBoxItem
     {
-        public int MyValueField { get; set; } //TValue matches the type of the value field
-        public string MyTextField { get; set; }
+        public int MyValueField { get; set; }
+        public string MyTextField { get; set; } = string.Empty;
     }
-
-    IEnumerable<MyDdlModel> myComboData = Enumerable.Range(1, 20).Select(x => new MyDdlModel { MyTextField = "item " + x, MyValueField = x });
-
-    //the same configuration applies if the "myComboData" object is null initially and is populated on some event
 }
 ````
 
 
 ## See Also
 
-  * [Blazor ComboBox Overview]({%slug components/combobox/overview%})
-  * [Live Demo: ComboBox](https://demos.telerik.com/blazor-ui/combobox/overview)
+* [Blazor ComboBox Overview]({%slug components/combobox/overview%})
+* [Live Demo: ComboBox](https://demos.telerik.com/blazor-ui/combobox/overview)

--- a/components/combobox/events.md
+++ b/components/combobox/events.md
@@ -26,7 +26,7 @@ This article explains the events available in the Telerik ComboBox for Blazor:
 
 The `ValueChanged` event fires upon every change of the user selection. When [custom values]({%slug components/combobox/custom-value%}) are enabled, it fires upon every keystroke, like in a regular `<input>` element.
 
-The examples below use binding to primitive types for brevity, you can use [full models]({%slug components/combobox/databind%}) as well. Make sure to review the [Data Binding - Missing Value or Data]({%slug components/combobox/databind%}#missing-value-or-data) section to provide all necessary parameters to the component if you do so. The type of the argument in the lambda expression must match the `Value` type of the component, and the `ValueField` type (if `ValueField` is set).
+The examples below use binding to string data for simplicity, but you can use [full models]({%slug components/combobox/databind%}) as well. Make sure to review the [Data Binding - Missing Value or Data]({%slug components/combobox/databind%}#missing-value-or-data) section to provide all necessary parameters to the component if you do so. The type of the argument in the lambda expression must match the `Value` type of the component, and the `ValueField` type (if `ValueField` is set).
 
 >caption Handle ValueChanged with list values
 

--- a/components/dropdownlist/data-bind.md
+++ b/components/dropdownlist/data-bind.md
@@ -16,42 +16,36 @@ This article explains the different ways to provide data to a DropDownList compo
 
 There are two key ways to bind data:
 
-* [Bind to Primitive Types](#primitive-types)
+* [Bind to Strings or Value Types](#strings-or-value-types)
 * [Bind to a Model](#bind-to-a-model)
 
-and some considerations you may find useful, such as showing the `DefaultText` when the value is out of the data source range:
+There are also some considerations you may find useful, such as showing the `DefaultText` when the value is out of the data source range:
 
   * [Considerations](#considerations)
     * [Value Out of Range](#value-out-of-range)
     * [Component Reference](#component-reference)
     * [Missing Value or Data](#missing-value-or-data)
 
-## Primitive Types
+## Strings or Value Types
 
-You can data bind the DropDownList to a simple collection of data. When you have a concrete list of options for the user to choose from, their string representation is often suitable for display and you do not need special models. 
+You can data bind the DropDownList to a collection of `string` or [value type](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-types) data (such as `int`, `decimal`, `bool`, and `Enum`). When you have a concrete list of options for the user to choose from, their string representation is often suitable for display and you do not need special models.
 
-To bind the dropdownlist to a primitive type (like `int`, `string`, `double`), you need to
+1. Provide an `IEnumerable<TItem>` of the desired type to its `Data` property.
+1. Set a corresponding `Value`. If the `Value` is `null`, it will be populated with the first item from the data source.
 
-1. provide an `IEnumerable<TItem>` of the desired type to its `Data` property
-1. set a corresponding `Value`. If the `Value` is `null`, it will be populated with the first item from the data source.
-
->caption Data binding a DropDownList to a primitive type
+>caption Data binding a DropDownList to strings
 
 ````CSHTML
-Bind to a List of a primitive type (stirng, int,...)
-
-<TelerikDropDownList Data="@MyList" @bind-Value="MyItem">
-</TelerikDropDownList>
+<TelerikDropDownList Data="@DropDownListData" @bind-Value="DropDownListValue" />
 
 @code {
-    protected List<string> MyList = new List<string>() { "first", "second", "third" };
+    private List<string> DropDownListData = new List<string>() { "first", "second", "third" };
 
-    protected string MyItem { get; set; }
+    private string DropDownListValue { get; set; } = string.Empty;
 
-    //Define a preselected value when the component initializes
     protected override void OnInitialized()
     {
-        MyItem = "second";
+        DropDownListValue = "second";
     }
 }
 ````
@@ -66,34 +60,32 @@ To bind the DropDownList to a model:
 1. Set the `TextField` and `ValueField` parameters to point to the corresponding property names of the model.
 1. Set the `Value` property to the initial value of the component (optional).
 
-> The `TextField` and `ValueField` parameters must point to model properties, which are of **primitive** type (`int`, `string`, etc.). The `Value` and `ValueField` types must match and also be primitive.
+> The `TextField` and `ValueField` parameters must point to `string` or [value type](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-types) properties. The `Value` parameter type must match the type of the `ValueField` property.
 
 >caption Data binding a DropDownList to a model
 
 ````CSHTML
-Bind to a collection of models
-
-<TelerikDropDownList Data="@myDdlData" TextField="MyTextField" ValueField="MyValueField" @bind-Value="selectedValue">
-</TelerikDropDownList>
+<TelerikDropDownList Data="@DropDownListData"
+                     @bind-Value="DropDownListValue"
+                     TextField="@nameof(DropDownListItem.Text)"
+                     ValueField="@nameof(DropDownListItem.Value)" />
 
 @code {
-    //in a real case, the model is usually in a separate file
-    //the model type and value field type must be provided to the dropdpownlist
-    public class MyDdlModel
-    {
-        public int MyValueField { get; set; }
-        public string MyTextField { get; set; }
-    }
+    private int DropDownListValue { get; set; }
 
-    int selectedValue { get; set; }
+    private IEnumerable<DropDownListItem> DropDownListData = Enumerable.Range(1, 20)
+        .Select(x => new DropDownListItem { Text = $"Item {x}", Value = x });
 
-    //Define a preselected value when the component initializes
     protected override void OnInitialized()
     {
-        selectedValue = 3;
+        DropDownListValue = 3;
     }
 
-    IEnumerable<MyDdlModel> myDdlData = Enumerable.Range(1, 20).Select(x => new MyDdlModel { MyTextField = "item " + x, MyValueField = x });
+    public class DropDownListItem
+    {
+        public int Value { get; set; }
+        public string Text { get; set; } = string.Empty;
+    }
 }
 ````
 
@@ -113,45 +105,51 @@ Handling such "unexpected" values is up to the application - for example, throug
  
 ### Component Reference
 
-The DropDownList is a generic component and its type comes from the model it is bound to and from the value field type. When bound to a primitive type, the reference is of that primitive type only.
+The DropDownList is a generic component and its type depends on the type of its `Data` and `Value`.
 
 <div class="skip-repl"></div>
-````Primitive
-Reference type when binding to primitive values
-
-<TelerikDropDownList @ref="myDdlRef" Data="@MyList" Value="@initialValue">
-</TelerikDropDownList>
+````String
+<TelerikDropDownList @ref="@DropDownListRef"
+                     Data="@DropDownListData"
+                     @bind-Value="DropDownListValue" />
 
 @code {
-    //the type of the generic component is determined by the type of the model you pass to it, and the type of its value field
-    Telerik.Blazor.Components.TelerikDropDownList<string, string> myDdlRef;
+    private TelerikDropDownList<string, string>? DropDownListRef { get; set; }
 
-    protected List<string> MyList = new List<string>() { "first", "second", "third" };
+    private List<string> DropDownListData = new List<string>() { "first", "second", "third" };
 
-    string initialValue { get; set; }
+    private string DropDownListValue { get; set; } = string.Empty;
 
-    //Define a preselected value when the component initializes
     protected override void OnInitialized()
     {
-        initialValue = "third";
+        DropDownListValue = "second";
     }
 }
 ````
 ````Model
-Reference when binding to model collections
+<TelerikDropDownList @ref="@DropDownListRef"
+                     Data="@DropDownListData"
+                     @bind-Value="DropDownListValue"
+                     TextField="@nameof(DropDownListItem.Text)"
+                     ValueField="@nameof(DropDownListItem.Value)" />
 
-<TelerikDropDownList @ref="myDdlRef" Data="@myDdlData" TextField="MyTextField" ValueField="MyValueField" Value="3">
-</TelerikDropDownList>
 @code {
-    //the type of the generic component is determined by the type of the model you pass to it, and the type of its value field
-    Telerik.Blazor.Components.TelerikDropDownList<MyDdlModel, int> myDdlRef;
+    private TelerikDropDownList<DropDownListItem, int>? DropDownListRef { get; set; }
 
-    IEnumerable<MyDdlModel> myDdlData = Enumerable.Range(1, 20).Select(x => new MyDdlModel { MyTextField = "item " + x, MyValueField = x });
-    
-    public class MyDdlModel
+    private int DropDownListValue { get; set; }
+
+    private IEnumerable<DropDownListItem> DropDownListData = Enumerable.Range(1, 20)
+        .Select(x => new DropDownListItem { Text = $"Item {x}", Value = x });
+
+    protected override void OnInitialized()
     {
-        public int MyValueField { get; set; }
-        public string MyTextField { get; set; }
+        DropDownListValue = 3;
+    }
+
+    public class DropDownListItem
+    {
+        public int Value { get; set; }
+        public string Text { get; set; } = string.Empty;
     }
 }
 ````
@@ -163,26 +161,25 @@ Reference when binding to model collections
 >caption DropDownList configuration if you cannot provide Value or Data
 
 ````CSHTML
-How to declare the dropdown if no Value or Data are provided
-
-<TelerikDropDownList Data="@myDdlData" TextField="MyTextField" ValueField="MyValueField" TValue="int" TItem="MyDdlModel">
-</TelerikDropDownList>
+<TelerikDropDownList Data="@DropDownListData"
+                     TItem="@DropDownListItem"
+                     TValue="@int"
+                     TextField="@nameof(DropDownListItem.Text)"
+                     ValueField="@nameof(DropDownListItem.Value)" />
 
 @code {
-	public class MyDdlModel //TItem matches the type of the model
-	{
-		public int MyValueField { get; set; } //TValue matches the type of the value field
-		public string MyTextField { get; set; }
-	}
+    private IEnumerable<DropDownListItem> DropDownListData = Enumerable.Range(1, 20)
+        .Select(x => new DropDownListItem { Text = $"Item {x}", Value = x });
 
-	IEnumerable<MyDdlModel> myDdlData = Enumerable.Range(1, 20).Select(x => new MyDdlModel { MyTextField = "item " + x, MyValueField = x });
-	
-	//the same configuration applies if the "myDdlData" object is null initially and is populated on some event
+    public class DropDownListItem
+    {
+        public int Value { get; set; }
+        public string Text { get; set; } = string.Empty;
+    }
 }
 ````
 
-
 ## See Also
 
-  * [DropDownList Overview]({%slug components/dropdownlist/overview%})
-  * [Live Demo: DropDownList](https://demos.telerik.com/blazor-ui/dropdownlist/index)
+* [DropDownList Overview]({%slug components/dropdownlist/overview%})
+* [Live Demo: DropDownList](https://demos.telerik.com/blazor-ui/dropdownlist/overview)

--- a/components/dropdownlist/events.md
+++ b/components/dropdownlist/events.md
@@ -26,7 +26,7 @@ The examples in this article use `string` values and simple data sources for bre
 
 The `ValueChanged` event fires upon every change of the user selection.
 
-The example below uses [binding]({%slug components/dropdownlist/databind%}) to primitive types for brevity. You can use full models as well. The type of the argument in the lambda expression must match the `Value` type of the component, and the `ValueField` type (if `ValueField` is set).
+The example below uses [binding]({%slug components/dropdownlist/databind%}) to string data for brevity. You can use full models as well. The type of the argument in the lambda expression must match the `Value` type of the component, and the `ValueField` type (if `ValueField` is set).
 
 >caption Handle DropDownList ValueChanged
 

--- a/components/gantt/gantt-tree/columns/bound.md
+++ b/components/gantt/gantt-tree/columns/bound.md
@@ -155,7 +155,7 @@ The Blazor Gantt Bound Column provides various parameters to configure the compo
 
 * For advanced operations such as filtering and sorting, you *must* set a `Field` to the column, and the field it points to must be a string or a value type (such as a number, string, DateTime, boolean).
     * If a `Field` is not set the column will not allow filtering, sorting and editing for the column.
-    * If the `Field` points to a custom object or something like an `IDictionary`, errors will be thrown upon those actions because there are no known data operations on non-primitive types in .NET.
+    * If the `Field` points to a custom object or something like an `IDictionary`, errors will be thrown upon those actions because there are no known data operations for reference types in .NET, except for strings.
 
 * If you don't set a `Title` for a column, the Gantt will take the `[Display(Name = "My Column Title")]` data annotation attribute from the model field. If that's not available either, the name of the field will be shown.
 

--- a/components/grid/columns/bound.md
+++ b/components/grid/columns/bound.md
@@ -131,7 +131,7 @@ You can use the following properties on bound columns:
 
 * For advanced operations such as grouping, filtering, sorting, you *must* set a `Field` to the column, and the field it points to must be a string or a value type (such as a number, string, DateTime, boolean).
     * If a `Field` is not set the column will not allow filtering, grouping, sorting and editing for the column.
-    * If the `Field` points to a custom object or something like an `IDictionary`, `List`, and `Array` errors will be thrown upon those actions because there are no known data operations on non-primitive types in .NET. To handle such scenarios you could flatten the collection and the underlying model.
+    * If the `Field` points to a custom object or something like an `IDictionary`, `List`, and `Array` errors will be thrown upon those actions because there are no known data operations for reference types in .NET, except for strings. To handle such scenarios you could flatten the collection and the underlying model.
     * To bind to nested (complex) models (also called navigation properties), use only the name of the field that holds the child class and its own field. For an example, see the [Bind to navigation properties in complex objects]({%slug grid-use-navigation-properties%}) article.
 
 * The `Field` of the column must point to a property in the model that has a public getter so that the grid can display data. For editing to be enabled, the property must have a public setter. For example:

--- a/components/listbox/overview.md
+++ b/components/listbox/overview.md
@@ -19,7 +19,7 @@ To use a Telerik ListBox for Blazor:
 
 1. Add the `TelerikListBox` tag.
 1. Set the `Data` parameter to an `IEnumerable<T>`.
-1. Set `TextField` to the property name that holds the string values to display in the ListBox. Skip this step when [binding the component to a collection of primitive values](#data-binding).
+1. Set `TextField` to the property name that holds the string values to display in the ListBox. Skip this step when [binding the component to a collection of strings or value type data](#data-binding).
 1. Set `SelectedItems` to an `IEnumerable<T>` to store or change the component selection. Optionally, [enable multiple selection]({%slug listbox-selection%}).
 1. Configure the [ListBox toolbar]({%slug listbox-toolbar%}) in `<ListBoxToolBarSettings>` and specify which buttons will be visible. By default, the toolbar shows all buttons. Each button requires an [event handler]({%slug listbox-events%}) to work.
 1. (optional) Set the `Width` and `Height` parameters, based on the number of toolbar buttons and desired number of visible items. The component will automatically show a vertical scrollbar if needed. Long items will wrap.
@@ -83,7 +83,7 @@ To use a Telerik ListBox for Blazor:
 
 ## Data Binding
 
-The ListBox supports [binding to a model class](#creating-blazor-listbox), which requires setting the [`TextField` parameter, unless the property name is `"Text"`](#listbox-parameters). Another option is to bind the component to a collection of primitive strings.
+The ListBox supports [binding to a model class](#creating-blazor-listbox), which requires setting the [`TextField` parameter, unless the property name is `"Text"`](#listbox-parameters). Another option is to bind the component to a collection of strings or [value type](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-types) data.
 
 >caption Bind ListBox to List&lt;string&gt;
 

--- a/components/multicolumncombobox/data-bind.md
+++ b/components/multicolumncombobox/data-bind.md
@@ -17,7 +17,7 @@ This article explains how to provide data to the MultiColumnComboBox component, 
 
 ## Bind to a Model
 
-Bind the MultiColumnComboBox to a model in your application. Unlike other dropdown components such as ComboBox or DropDownList, binding to a collection of primitive types is not supported.
+Bind the MultiColumnComboBox to a model in your application. Unlike other drop down components such as ComboBox or DropDownList, binding to a collection of strings, primitives, or value types is not supported.
 
 Consult the [MultiColumnComboBox basic usage example]({%slug multicolumncombobox-overview%}#creating-multiColumnComboBox).
 

--- a/components/multiselect/data-bind.md
+++ b/components/multiselect/data-bind.md
@@ -16,14 +16,14 @@ This article explains the different ways to provide data to a MultiSelect compon
 
 There are two key ways to bind data:
 
-* [Primitive Types](#primitive-types)
+* [Strings and Value Types](#strings-and-value-types)
 * [Model](#bind-to-a-model)
 
 There are also some [considerations](#considerations) to keep in mind.
 
-## Primitive Types
+## Strings and Value Types
 
-You can data bind the MultiSelect to a simple collection of data (number - such as `int`, `double` and so on, `string`, `Guid`, `Enum`). When you have a concrete list of options for the user to choose from, their string representation is often suitable for display and you do not need special models.
+You can data bind the MultiSelect to a collection of `string` or [value type](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-types) data (such as `int`, `decimal`, `bool`, `Guid`, and `Enum`). When you have a concrete list of options for the user to choose from, their string representation is often suitable for display and you do not need special models.
 
 To bind the MultiSelect, you need to:
 
@@ -132,43 +132,50 @@ The MultiSelect component attempts to infer the type of its model and value base
 
 ### Reference
 
-The MultiSelect component is generic and its type depends on the type of the model you provide as its `Data` collection.
+The MultiSelect is a generic component and its type depends on the type of its `Data` and `Value`.
 
 <div class="skip-repl"></div>
-````Primitive
-@*Reference type when binding to primitive collections*@
+````String
+@*Reference type when binding to a string collection*@
 
-<TelerikMultiSelect @ref="@MultiSelectRef" Data="@Options" @bind-Value="@TheValues" />
+<TelerikMultiSelect @ref="@MultiSelectRef"
+                    Data="@MultiSelectData"
+                    @bind-Value="@MultiSelectValue" />
 
+@code {
+    private TelerikMultiSelect<string, string>? MultiSelectRef { get; set; }
 
-@code{
-    TelerikMultiSelect<string, string> MultiSelectRef { get; set; }
+    private List<string> MultiSelectValue { get; set; } = new();
 
-    List<string> TheValues { get; set; }
-    List<string> Options { get; set; } = new List<string> { "first", "second", "third" };
+    private List<string> MultiSelectData { get; set; } = new List<string> { "first", "second", "third" };
 }
 ````
 ````Model
-@*Reference when binding to model collections*@
+@*Reference when binding to a model collection*@
 
-<TelerikMultiSelect @ref="@MultiSelectRef" Data="@Options" @bind-Value="@TheValues"
-                    TextField="StringRepresentation" ValueField="MyValueField" />
+<TelerikMultiSelect @ref="@MultiSelectRef"
+                    Data="@MultiSelectData"
+                    @bind-Value="@MultiSelectValue"
+                    TextField="@nameof(MultiSelectItem.Text)"
+                    ValueField="@nameof(MultiSelectItem.Value)" />
 
-@code{
-    TelerikMultiSelect<OptionsModel, int> MultiSelectRef { get; set; }
+@code {
+    private TelerikMultiSelect<MultiSelectItem, int>? MultiSelectRef { get; set; }
 
-    List<int> TheValues { get; set; }
-    List<OptionsModel> Options { get; set; } = new List<OptionsModel>
+    private List<int> MultiSelectValue { get; set; } = new();
+
+    private List<MultiSelectItem> MultiSelectData { get; set; } = new List<MultiSelectItem>()
     {
-        new OptionsModel { StringRepresentation = "first",  MyValueField = 1 },
-        new OptionsModel { StringRepresentation = "second", MyValueField = 2 },
-        new OptionsModel { StringRepresentation = "third",  MyValueField = 3 }
+        new MultiSelectItem { Text = "first",  Value = 1 },
+        new MultiSelectItem { Text = "second", Value = 2 },
+        new MultiSelectItem { Text = "third",  Value = 3 }
     };
 
-    public class OptionsModel
+    public class MultiSelectItem
     {
-        public string StringRepresentation { get; set; }
-        public int MyValueField { get; set; } // this determines the type of the values list
+        public string Text { get; set; } = string.Empty;
+    
+        public int Value { get; set; }
     }
 }
 ````
@@ -180,26 +187,30 @@ In case you cannot provide either of a `Value`, or `Data`, or both when the comp
 >caption MultiSelect configuration if you cannot provide Value or Data
 
 ````CSHTML
-@*How to declare the multiselect if no Value or Data are provided*@
+@*How to declare the MultiSelect if no Value or Data are provided*@
 
-<TelerikMultiSelect Data="@MyOptions" TextField="MyTextField" ValueField="MyValueField" TValue="int" TItem="MyDdlModel">
+<TelerikMultiSelect Data="@MultiSelectData"
+                    TItem="@MultiSelectItem"
+                    TValue="@int"
+                    TextField="@nameof(MultiSelectItem.Text)"
+                    ValueField="@nameof(MultiSelectItem.Value)">
 </TelerikMultiSelect>
 
 @code {
-    public class MyDdlModel //TItem matches the type of the model
+    //The same configuration applies if MultiSelectData is null initially and is populated later
+    private IEnumerable<MultiSelectItem> MultiSelectData = Enumerable.Range(1, 20)
+        .Select(x => new MultiSelectItem { Text = "item " + x, Value = x });
+
+    public class MultiSelectItem
     {
-        public int MyValueField { get; set; } //TValue matches the type of the value field
-        public string MyTextField { get; set; }
+        public string Text { get; set; } = string.Empty;
+
+        public int Value { get; set; }
     }
-
-    IEnumerable<MyDdlModel> MyOptions = Enumerable.Range(1, 20).Select(x => new MyDdlModel { MyTextField = "item " + x, MyValueField = x });
-
-    //the same configuration applies if the "MyOptions" object is null initially and is populated on some event
 }
 ````
 
 
 ## See Also
 
-  * [AutoComplete Overview]({%slug autocomplete-overview%})
-  * [Live Demo: AutoComplete](https://demos.telerik.com/blazor-ui/autocomplete/overview)
+* [Live Demo: MultiSelect](https://demos.telerik.com/blazor-ui/multiselect/overview)

--- a/components/radiogroup/data-bind.md
+++ b/components/radiogroup/data-bind.md
@@ -16,7 +16,7 @@ This article explains the different ways to provide data to a RadioGroup compone
 
 There are two key ways to bind data:
 
-* [Bind to Primitive Types](#primitive-types)
+* [Bind to Strings or Value Types](#strings-or-value-types)
 * [Bind to a Model](#bind-to-a-model)
 
 and some considerations you may find useful, such as handling values not in the list, or when the value is out of the data source range:
@@ -26,24 +26,24 @@ and some considerations you may find useful, such as handling values not in the 
 	* [Component Reference](#component-reference)
 	* [Missing Value or Data](#missing-value-or-data)
 
-## Primitive Types
+## Strings or Value Types
 
-You can data bind the RadioGroup to a simple collection of data. When you have a concrete list of options for the user to choose from, their string representation is often suitable for display and you do not need special models. 
-
-To bind the RadioGroup to a primitive type (like `int`, `string`, `double`), you need to
+You can data bind the RadioGroup to a collection of `string` or [value type](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-types) data (such as `int`, `decimal`, `bool`, and `Enum`). When you have a concrete list of options for the user to choose from, their string representation is often suitable for display and you do not need special models.
 
 1. Provide an `IEnumerable<TItem>` of the desired type to its `Data` property
 1. Set a corresponding `Value`.
 
->caption Data binding a RadioGroup to a primitive type
+>caption Data binding a RadioGroup to strings
 
 ````CSHTML
-@SelectedValue
+RadioGroupValue: @RadioGroupValue
 <br />
-<TelerikRadioGroup Data="@Data" @bind-Value="@SelectedValue"></TelerikRadioGroup>
-@code{
-    string SelectedValue { get; set; }
-    IEnumerable<string> Data { get; set; } = new List<string> { "first", "second", "third" };
+<TelerikRadioGroup Data="@RadioGroupData" @bind-Value="@RadioGroupValue" />
+
+@code {
+    private string RadioGroupValue { get; set; } = string.Empty;
+
+    private IEnumerable<string> RadioGroupData { get; set; } = new List<string> { "first", "second", "third" };
 }
 ````
 
@@ -60,30 +60,28 @@ To bind the RadioGroup to a model:
 >caption Data binding a RadioGroup to a model and collection of models
 
 ````CSHTML
-Chosen gender: @( ChosenGender == 0 ? "no selection yet" : ChosenGender.ToString() )
+Selected Gender Id: @( RadioGroupValue == default ? "None yet" : RadioGroupValue.ToString() )
 <br />
+<TelerikRadioGroup Data="@RadioGroupData"
+                   @bind-Value="@RadioGroupValue"
+                   ValueField="@nameof(Gender.Id)"
+                   TextField="@nameof(Gender.Text)" />
 
-<TelerikRadioGroup Data="@GenderOptions"
-                   @bind-Value="@ChosenGender"
-                   ValueField="@nameof(GenderModel.GenderId)"
-                   TextField="@nameof(GenderModel.GenderText)">
-</TelerikRadioGroup>
+@code {
+    private int RadioGroupValue { get; set; }
 
-@code{
-    int ChosenGender { get; set; }
-
-    List<GenderModel> GenderOptions { get; set; } = new List<GenderModel>
+    private List<Gender> RadioGroupData { get; set; } = new List<Gender>()
     {
-        new GenderModel { GenderId = 1, GenderText = "Female" },
-        new GenderModel { GenderId = 2, GenderText = "Male" },
-        new GenderModel { GenderId = 3, GenderText = "Other" },
-        new GenderModel { GenderId = 4, GenderText = "Prefer not to say" },
+        new Gender { Id = 1, Text = "Female" },
+        new Gender { Id = 2, Text = "Male" },
+        new Gender { Id = 3, Text = "Other" },
+        new Gender { Id = 4, Text = "Prefer Not to Say" },
     };
 
-    public class GenderModel
+    public class Gender
     {
-        public int GenderId { get; set; }
-        public string GenderText { get; set; }
+        public int Id { get; set; }
+        public string Text { get; set; }
     }
 }
 ````
@@ -104,48 +102,45 @@ You should avoid values in the data that match the `default` of their type (such
  
 ### Component Reference
 
-The RadioGroup is a generic component and its type comes from the model it is bound to and from the value field type. When bound to a primitive type, the reference is of that primitive type only.
+The RadioGroup is a generic component and its type depends on the type of its `Data` and `Value`.
 
 <div class="skip-repl"></div>
-````Primitive
-Reference type when binding to primitive values
+````String
+<TelerikRadioGroup @ref="@RadioGroupRef"
+                   Data="@RadioGroupData"
+                   @bind-Value="@RadioGroupValue" />
+@code {
+    private TelerikRadioGroup<string, string>? RadioGroupRef { get; set; }
 
-<TelerikRadioGroup Data="@Data" @bind-Value="@SelectedValue" @ref="@RadioGroupRef"></TelerikRadioGroup>
-@code{
-    TelerikRadioGroup<string, string> RadioGroupRef { get; set; }
+    private string RadioGroupValue { get; set; } = string.Empty;
 
-    string SelectedValue { get; set; }
-    IEnumerable<string> Data { get; set; } = new List<string> { "first", "second", "third" };
+    private IEnumerable<string> RadioGroupData { get; set; } = new List<string> { "first", "second", "third" };
 }
-
 ````
 ````Model
-Reference when binding to model collections
+<TelerikRadioGroup @ref="@RadioGroupRef"
+                   Data="@RadioGroupData"
+                   @bind-Value="@RadioGroupValue"
+                   ValueField="@nameof(Gender.Id)"
+                   TextField="@nameof(Gender.Text)" />
 
-<TelerikRadioGroup Data="@GenderOptions"
-                   @bind-Value="@ChosenGender"
-                   @ref="@RadioGroupRef"
-                   ValueField="@nameof(GenderModel.GenderId)"
-                   TextField="@nameof(GenderModel.GenderText)">
-</TelerikRadioGroup>
+@code {
+    private TelerikRadioGroup<Gender, int>? RadioGroupRef { get; set; }
 
-@code{
-    TelerikRadioGroup<GenderModel, int> RadioGroupRef { get; set; }
+    private int RadioGroupValue { get; set; }
 
-    int ChosenGender { get; set; }
-
-    List<GenderModel> GenderOptions { get; set; } = new List<GenderModel>
+    private List<Gender> RadioGroupData { get; set; } = new List<Gender>()
     {
-        new GenderModel { GenderId = 1, GenderText = "Female" },
-        new GenderModel { GenderId = 2, GenderText = "Male" },
-        new GenderModel { GenderId = 3, GenderText = "Other" },
-        new GenderModel { GenderId = 4, GenderText = "Prefer not to say" },
+        new Gender { Id = 1, Text = "Female" },
+        new Gender { Id = 2, Text = "Male" },
+        new Gender { Id = 3, Text = "Other" },
+        new Gender { Id = 4, Text = "Prefer Not to Say" },
     };
 
-    public class GenderModel
+    public class Gender
     {
-        public int GenderId { get; set; }
-        public string GenderText { get; set; }
+        public int Id { get; set; }
+        public string Text { get; set; }
     }
 }
 ````
@@ -157,39 +152,30 @@ Reference when binding to model collections
 >caption RadioGroup configuration if you cannot provide Value or Data
 
 ````CSHTML
-How to declare the radio button list if no Value or Data are provided
+<TelerikRadioGroup Data="@RadioGroupData"
+                   TItem="@Gender"
+                   TValue="@int"
+                   ValueField="@nameof(Gender.Id)"
+                   TextField="@nameof(Gender.Text)" />
 
-<TelerikRadioGroup Data="@GenderOptions"
-                   TItem="GenderModel" TValue="int"
-                   ValueField="@nameof(GenderModel.GenderId)"
-                   TextField="@nameof(GenderModel.GenderText)">
-</TelerikRadioGroup>
-
-@code{
-    TelerikRadioGroup<GenderModel, int> RadioGroupRef { get; set; }
-
-    int ChosenGender { get; set; }
-
-    List<GenderModel> GenderOptions { get; set; } = new List<GenderModel>
+@code {
+    private List<Gender> RadioGroupData { get; set; } = new List<Gender>()
     {
-        new GenderModel { GenderId = 1, GenderText = "Female" },
-        new GenderModel { GenderId = 2, GenderText = "Male" },
-        new GenderModel { GenderId = 3, GenderText = "Other" },
-        new GenderModel { GenderId = 4, GenderText = "Prefer not to say" },
+        new Gender { Id = 1, Text = "Female" },
+        new Gender { Id = 2, Text = "Male" },
+        new Gender { Id = 3, Text = "Other" },
+        new Gender { Id = 4, Text = "Prefer Not to Say" },
     };
 
-    public class GenderModel //TItem matches the type of the model
+    public class Gender
     {
-        public int GenderId { get; set; } //TValue matches the type of the value field
-        public string GenderText { get; set; }
+        public int Id { get; set; }
+        public string Text { get; set; }
     }
-
-    //the same configuration applies if the "myDdlData" object is null initially and is populated on some event
 }
 ````
 
-
 ## See Also
 
-  * [RadioGroup Overview]({%slug radiogroup-overview%})
-  * [Live Demo: RadioGroup](https://demos.telerik.com/blazor-ui/radiogroup/overview)
+* [RadioGroup Overview]({%slug radiogroup-overview%})
+* [Live Demo: RadioGroup](https://demos.telerik.com/blazor-ui/radiogroup/overview)

--- a/components/radiogroup/events.md
+++ b/components/radiogroup/events.md
@@ -51,7 +51,7 @@ The `OnChange` event represents a user action - confirmation of the current valu
 
 The `ValueChanged` event fires upon every change of the user selection.
 
-The example below uses [binding]({%slug radiogroup-databind%}) to primitive types for brevity, you can use full models as well.
+The example below uses [binding]({%slug radiogroup-databind%}) to string data for brevity. You can use a model class as well.
 
 >caption Handle ValueChanged
 

--- a/components/radiogroup/overview.md
+++ b/components/radiogroup/overview.md
@@ -57,7 +57,7 @@ Chosen gender: @( ChosenGender == 0 ? "no selection yet" : ChosenGender.ToString
 
 ## Data Binding
 
-The Blazor RadioGroup supports data binding to primitive types and a model. [Read more about the Blazor RadioGroup data binding]({%slug radiogroup-databind%}).
+The Blazor RadioGroup supports data binding to strings, [value type](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-types) data, and a model collection. [Read more about the Blazor RadioGroup data binding]({%slug radiogroup-databind%}).
 
 ## Layout
 

--- a/components/treelist/columns/bound.md
+++ b/components/treelist/columns/bound.md
@@ -161,7 +161,7 @@ You can use the following properties on bound columns:
 
 * For advanced operations such as filtering and sorting, you *must* set a `Field` to the column, and the field it points to must be a string or a value type (such as a number, string, DateTime, boolean).
     * If a `Field` is not set the column will not allow filtering, sorting and editing for the column.
-    * If the `Field` points to a custom object or something like an `IDictionary`, errors will be thrown upon those actions because there are no known data operations on non-primitive types in .NET.
+    * If the `Field` points to a custom object or something like an `IDictionary`, errors will be thrown upon those actions because there are no known data operations for reference types in .NET, except for strings.
     * To bind to nested (complex) models (also called navigation properties), use only the name of the field that holds the child class and its own field. For an example, see the [Bind to navigation properties in complex objects]({%slug grid-use-navigation-properties%}) article.
 
 * The treelist skips fields marked with the [`IgnoreDataMemberAttribute`](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.serialization.ignoredatamemberattribute) when performing CUD operations. Its presence indicates that this property does not need to be part of the serialized data anyway, and skipping such fields allows [Lazy Loading Proxies in EF](https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.proxiesextensions.uselazyloadingproxies?view=efcore-3.1) to work.

--- a/getting-started/value-vs-data-binding.md
+++ b/getting-started/value-vs-data-binding.md
@@ -56,7 +56,7 @@ There is no two-way binding in this case, the flow of the data is from the paren
 
 Data binding includes the following steps:
 
-* Creating a collection with the desired set of models/primitive types in the view-model. You would usually get it from a data service specific to the app.
+* Creating a collection with the desired set of [reference](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/reference-types) or [value](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-types) types in the view-model. You would usually get it from a data service specific to the app.
 
 * Pointing the `Data` parameter of the Telerik component to that collection.
 

--- a/knowledge-base/combobox-not-closing.md
+++ b/knowledge-base/combobox-not-closing.md
@@ -30,9 +30,7 @@ In order for the ComboBox to function properly, the `Value` parameter should be 
 
 ### Problematic Setup
 
-The following example demonstrates the described problematic behavior caused by different data types provided to `Value` and `ValueField` parameters - the `ValueField`is of type `int` and the `Value` is bound to an instance of the model (`MyDdlModel`).
-
-* Note: This behavior is observed when dealing with data where the difference is of type primitive data - model. If you try working just with different primitive types ( for example `int` - `string`) the application will not run.
+The following example demonstrates the described problematic behavior caused by different data types provided to the `Value` and `ValueField` parameters. The `ValueField` property is of type `int` and the `Value` is bound to an instance of `MyDdlModel`.
 
 ````CSHTML
 @* Try selecting an item - selection is not done and the popup is not closed until it loses focus *@

--- a/knowledge-base/dropdown-all-items-are-selected.md
+++ b/knowledge-base/dropdown-all-items-are-selected.md
@@ -39,17 +39,17 @@ Why the component matches all items to the selected one?
 Such unexpected behavior may occur if the ComboBox or DropDownList component are bound to a collection of objects. The possible reasons are related to incorrect configuration:
 
 * There is no `ValueField` set. Without it, the component cannot compare items.
-* `Value` and `TValue` are not of **primitive** type, while they should be (e.g. `int`, `string`, `Guid`, etc.)
+* `Value` and `TValue` are not strings or value types, while they should be (for example, `int`, `string`, `Guid`).
 * The `ValueField` points to a model property, which is not unique for all items.
-* The `ValueField` points to a model property, which is equal to the default value for its type (`null`, `0`, `String.Empty`, etc.)
+* The `ValueField` points to a model property, which is equal to the default value for its type (for example, `null`, `0`, `String.Empty`).
 
 
 ## Solution
 
 When the ComboBox or DropDownList are data bound to a collection of complex objects, make sure that:
 
-* The component `Value` is of primitive type.
-* `ValueField` is set and points to a primitive property of the model.
+* The component `Value` is a `string` or [value type](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-types).
+* `ValueField` is set and points to a string property or a value-type property of the model class.
 * The `Value` and `ValueField` property types match.
 * The `ValueField` property value should be unique for each item.
 * If `TItem` is set, it must match the model type.
@@ -65,7 +65,7 @@ The test page below demonstrates several incorrect and correct configurations fo
 ````CSHTML
 <div id="dropdown-container">
     <div>
-        Incorrect (no ValueField, Value is not primitive): <br />
+        Incorrect (no ValueField, Value is a not a string or value type): <br />
         <TelerikDropDownList @ref="@DropDownRef1"
                                 Data="@ListItems"
                                 @bind-Value="@SelectedListItem1"
@@ -91,7 +91,7 @@ The test page below demonstrates several incorrect and correct configurations fo
     </div>
 
     <div class="correct">
-        <strong>Correct (ValueField is unique and primitive):</strong> <br />
+        <strong>Correct (ValueField is unique and value type):</strong> <br />
         <TelerikDropDownList @ref="@DropDownRef4"
                                 Data="@ListItems"
                                 @bind-Value="@SelectedIntValue4"

--- a/knowledge-base/dropdowns-get-model.md
+++ b/knowledge-base/dropdowns-get-model.md
@@ -1,8 +1,8 @@
 ---
-title: Get model from dropdown
-description: how to get a model from a dropdown instead of a primitive value.
+title: Get Model from Drop Down
+description: How to get a model from a drop down instead of a primitive or value-type value.
 type: how-to
-page_title: Get model from dropdown
+page_title: Get Model from Drop Down
 slug: dropdowns-get-model
 position: 
 tags: 
@@ -23,11 +23,11 @@ res_type: kb
 
 ## Problem
 
-I want to get an instance of my model when I select an item from a dropdown (such as a DropDownList, ComboBox, AutoComplete, MultiSelect). I can get only a primitive type that is the type of the `Value` and `ValueField`.
+I want to get an instance of my model when I select an item from a dropdown (such as a DropDownList, ComboBox, AutoComplete, MultiSelect). I can get only a string or a value type that is the type of the `Value` and `ValueField`.
 
 ## Description
 
-The dropdowns provide a primitive `Value` so that [validation]({%slug common-features/input-validation%}) can work, and so that other data source operations (such as filtering) can work. The Value and Text cannot be classes (models) because that would prevent validation from working and filtering/comparing entire classes is an operation that is not defined.
+All Telerik UI for Blazor dropdown components support a string and [built-in value-type](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-types) `Value` so that [validation]({%slug common-features/input-validation%}) and filtering can work. The Value and Text cannot be classes (models) because that would prevent validation from working and filtering/comparing entire classes is an operation that is not defined.
 
 ## Solution
 

--- a/knowledge-base/grid-aggregates-and-datatable.md
+++ b/knowledge-base/grid-aggregates-and-datatable.md
@@ -90,7 +90,7 @@ This sample contains a solution for calculating them on the server over all data
                 x =>
                 {
                     // This is mandatory if you are having some data with empty values (nulls)
-                    // DBNull is not parsable to other primitive types and we should convert it manually
+                    // DBNull is not parsable to other value types and we should convert it manually
                     if (x.Value == DBNull.Value)
                     {
                         return null;
@@ -216,7 +216,7 @@ You can, however, add the desired aggregate functions and let .ToDataSourceResul
                 x =>
                 {
                     // This is mandatory if you are having some data with empty values (nulls)
-                    // DBNull is not parsable to other primitive types and we should convert it manually
+                    // DBNull is not parsable to other value types and we should convert it manually
                     if (x.Value == DBNull.Value)
                     {
                         return null;

--- a/knowledge-base/grid-bind-navigation-property-complex-object.md
+++ b/knowledge-base/grid-bind-navigation-property-complex-object.md
@@ -24,7 +24,7 @@ res_type: kb
 
 ## Description
 
-I bind the Grid to Data with complex objects in its model, not only primitive types.
+I bind the Grid to Data with complex objects in its model, not only strings, primitive and value types.
 
 How to use complex objects in my model and show nested (navigation) properties information in the Grid?
 

--- a/knowledge-base/grid-filter-column-list.md
+++ b/knowledge-base/grid-filter-column-list.md
@@ -257,7 +257,7 @@ The example below includes two Grids - one for each `FilterMode`.
 
 ## Notes
 
-.NET doesn't provide a built-in mechanism for filtering or comparing collections. As a result, built-in Grid data operations exist only for primitive types like `string`, `int`, `bool`, `DateTime`.
+.NET doesn't provide a built-in mechanism for filtering or comparing collections. As a result, built-in Grid data operations exist only for `string` and [value types](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-types) like `int`, `bool`, `DateTime`, and so on.
 
 
 ## See Also

--- a/knowledge-base/grid-save-load-state-localstorage.md
+++ b/knowledge-base/grid-save-load-state-localstorage.md
@@ -44,7 +44,7 @@ Then, follow these steps:
 1. Subscribe to the [Grid `OnStateInit` event]({%slug grid-state%}#onstatechanged) to configure the initial state of the Grid programmatically.
 1. Obtain the previously saved Grid state information from `localStorage`, deserialize it and set it to the `args.GridState` property of the `OnStateInit` event argument.
     * Using `localStorage` requires JavaScript. Blazor doesn't allow JSInterop calls during pre-rendering. To avoid runtime exceptions, wrap the JSInterop call in `OnStateInit` in a try-catch block. 
-1. Some aspects of the Grid state depend on data item references, for example selected items, expanded hierarchy items, or edited items. To restore these successfully, override the `Equals` method of the Grid model class. This will allow .NET to compare data items by a primitive value (ID), rather than by reference. Reference comparison will always return `false` after serialization and deserialization.
+1. Some aspects of the Grid state depend on data item references, for example selected items, expanded hierarchy items, or edited items. To restore these successfully, override the `Equals` method of the Grid model class. This will allow .NET to [compare data items by a value (ID), rather than by reference](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/built-in-types). Reference comparison will always return `false` (except for strings) after serialization and deserialization.
 
 For more information about `localStorage`, see:
 
@@ -181,7 +181,7 @@ For more information about `localStorage`, see:
 
         public List<Assignment> Assignments { get; set; }
 
-        // Example for comparing data items by primitive values (ID), rather than by reference.
+        // Example for comparing data items by value (ID), rather than by reference.
         // Used for Grid state operations that are related to items (e.g. editing, selection, hierarchy).
         public override bool Equals(object obj)
         {


### PR DESCRIPTION
Triggered by docs feedback. Refer to:

https://learn.microsoft.com/en-us/dotnet/api/system.type.isprimitive?view=net-8.0#remarks

https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/built-in-types

So, our mentioning of "primitive" types is more restrictive than it should be.