### PR TITLE
fix(popover): use correct enum name and type for showon param

### DIFF
--- a/components/popover/overview.md
+++ b/components/popover/overview.md
@@ -64,7 +64,7 @@ The Blazor Popover provides parameters to configure the component. Also check th
 | `Offset` | `double ` | The space between the Popover and its anchor in pixels. |
 | `Position` | `PopoverPosition  ` enum <br /> (`Top`) | The position relative to the target element at which the Popover will be shown. [Read more about Popover position...]({%slug popover-position-collision%}) |
 | `ShowCallout` | `bool` <br /> (`true`) | Defines if the callout is rendered. |
-| `ShowOn` | `PopoverShowEvent` enum <br /> (`Click`) | The browser event that will display the Popover (`MouseEnter` or `Click`). When you set the `ShowOn` parameter to `Click`, the Popover will hide when the user clicks outside the component. If the parameter's value is `MouseEnter`, the Popover will hide when the mouse pointer leaves. |
+| `ShowOn` | `PopOverShowOn?` enum <br /> (`null`) | The browser event that will display the Popover (`MouseEnter` or `Click`). When you set the `ShowOn` parameter to `Click`, the Popover will hide when the user clicks outside the component. If the parameter's value is `MouseEnter`, the Popover will hide when the mouse pointer leaves. |
 
 ### Styling and Appearance
 


### PR DESCRIPTION
- The correct enum is https://docs.telerik.com/blazor-ui/api/telerik.blazor.components.popovershowon
- it is a nullable parameter with no default value, as this way it caters for the case where programmatic approach only is desired.

The default value here is misleading - this was never the case in the component and is an issue only in the documentation