### PR TITLE
docs(floating): fix the CSS selector for prefix and floating label

### DIFF
--- a/_contentTemplates/common/inputs.md
+++ b/_contentTemplates/common/inputs.md
@@ -21,7 +21,7 @@ To ensure both the FloatingLabel and the prefix content are properly displayed, 
 
 ````CSHTML
 <style>
-    .custom-label-class .k-label {
+    .custom-label-class .k-floating-label {
         margin-left: 30px;
     }
 </style>


### PR DESCRIPTION
Note to external contributors: make sure to sign our Contribution License Agreement (CLA) for Blazor UI first:

https://forms.office.com/Pages/ResponsePage.aspx?id=Z2om2-DLJk2uGtBYH-A1NbWxVqugKN5DvVp8I-1AgOBURFBVSkwyMlA1TkFDVFdMNU1aM1o1UlZQOC4u
