### PR TITLE
docs(Dropdowns): remove outdated information

### DIFF
--- a/knowledge-base/dropdowns-get-model.md
+++ b/knowledge-base/dropdowns-get-model.md
@@ -319,5 +319,3 @@ The example below copies the Telerik DropDownList rendering and uses a grid to p
     }
 }
 ````
-
->tip You may want to vote for and follow the implementation of a ready-made Telerik component that will let you nest custom content in the dropdown [here](https://feedback.telerik.com/blazor/1506370-dropdown-container-popup-component-tied-to-an-anchor-for-positioning).


### PR DESCRIPTION
Remove the tip that links to an already implemented feature request.