### PR TITLE
chore: remove head metadata description suffix

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -702,7 +702,7 @@ defaults:
         category: "default"
         product: "blazor"
         editable: true
-        description_suffix: "Read more in Telerik UI for Blazor Documentation."
+        description_suffix: ""
 -
     scope:
         path: "blazor"
@@ -765,7 +765,7 @@ defaults:
         category: "default"
         product: "blazor"
         editable: true
-        description_suffix: "Read more in our Blazor Knowledge Base articles."
+        description_suffix: ""
 -
     scope:
         path: "web.config"


### PR DESCRIPTION
We append a suffix to each page's metadata description. The guidelines from our marketing team is that these add little to no value and simply bloat the content, hence we should remove them.