### PR TITLE
docs(Scheduler):revamp resource grouping header template docs

### DIFF
--- a/components/scheduler/templates/appointment.md
+++ b/components/scheduler/templates/appointment.md
@@ -137,5 +137,5 @@ You can also style the entire appointments by adding a class to their wrapping e
 
 ## See Also
 
- * [Live Demo: Scheduler Templates](https://demos.telerik.com/blazor-ui/scheduler/appointment-templates)
+ * [Live Demo: Scheduler Templates](https://demos.telerik.com/blazor-ui/scheduler/templates)
 

--- a/components/scheduler/templates/dateheader.md
+++ b/components/scheduler/templates/dateheader.md
@@ -100,5 +100,5 @@ The `DateHeaderTemplate` can be defined for the [day and week Scheduler views]({
 
 ## See Also
 
- * [Live Demo: Scheduler Templates](https://demos.telerik.com/blazor-ui/scheduler/dateheader-templates)
+ * [Live Demo: Scheduler Templates](https://demos.telerik.com/blazor-ui/scheduler/templates)
 

--- a/components/scheduler/templates/resource-grouping-header.md
+++ b/components/scheduler/templates/resource-grouping-header.md
@@ -15,7 +15,7 @@ You can use the `SchedulerResourceGroupHeaderTemplate` to customize the renderin
 The `SchedulerResourceGroupHeaderTemplate`:
 * Is invoked for each resource when the Scheduler is configured to have resources and grouping.
 * Applies in both horizontal and vertical grouping.
-* Can be defined at the root level of the Scheduler and individually for each [Scheduler views]({%slug scheduler-views-overview%}). When configured at the root, the template applies to all views. If a `SchedulerResourceGroupHeaderTemplate` is defined at the view level, it will override the root-level template for that specific view.
+* Can be defined individually for each [Scheduler views]({%slug scheduler-views-overview%}).
 
 The `context` of the template is a `SchedulerResourceGroupHeaderTemplateContext` object that contains:
 
@@ -32,14 +32,6 @@ The `context` of the template is a `SchedulerResourceGroupHeaderTemplateContext`
                   @bind-Date="@StartDate"
                   Height="600px"
                   Width="900px">
-    <SchedulerResourceGroupHeaderTemplate>
-        Text: @context.Text
-        <br />
-        Value: @context.Value
-        <br />
-        Field: @context.Field
-        <br />
-    </SchedulerResourceGroupHeaderTemplate>
     <SchedulerViews>
         <SchedulerDayView StartTime="@DayStart">
             <SchedulerResourceGroupHeaderTemplate>
@@ -62,9 +54,23 @@ The `context` of the template is a `SchedulerResourceGroupHeaderTemplateContext`
                 </p>
             </SchedulerResourceGroupHeaderTemplate>
         </SchedulerDayView>
-        <SchedulerWeekView StartTime="@DayStart" />
-        <SchedulerMultiDayView StartTime="@DayStart" />
-        <SchedulerMonthView></SchedulerMonthView>
+        <SchedulerWeekView StartTime="@DayStart">
+            <SchedulerResourceGroupHeaderTemplate>
+                <div>
+                    <span class="meeting-title">@context.Text</span>
+                </div>
+            </SchedulerResourceGroupHeaderTemplate>
+        </SchedulerWeekView>
+        <SchedulerMonthView>
+            <SchedulerResourceGroupHeaderTemplate>
+                Text: @context.Text
+                <br />
+                Value: @context.Value
+                <br />
+                Field: @context.Field
+                <br />
+            </SchedulerResourceGroupHeaderTemplate>
+        </SchedulerMonthView>
     </SchedulerViews>
     <SchedulerResources>
         <SchedulerResource Field="@nameof(AppointmentModel.RoomId)" TextField="Name" ValueField="Id" Data="@Rooms"></SchedulerResource>
@@ -75,6 +81,14 @@ The `context` of the template is a `SchedulerResourceGroupHeaderTemplateContext`
 </TelerikScheduler>
 
 <TelerikTooltip TargetSelector=".tooltip-target" />
+
+<style>
+    .meeting-title {
+        text-transform: uppercase;
+        font-style: italic;
+        color: red;
+    }
+</style>
 
 @code {
     private List<string> GroupingResources = new List<string> { "RoomId" };
@@ -172,5 +186,5 @@ The `context` of the template is a `SchedulerResourceGroupHeaderTemplateContext`
 
 ## See Also
 
- * [Live Demo: Scheduler Templates](https://demos.telerik.com/blazor-ui/scheduler/resourcegroupheader-templates)
+ * [Live Demo: Scheduler Templates](https://demos.telerik.com/blazor-ui/scheduler/templates)
 

--- a/components/scheduler/templates/resource-grouping-header.md
+++ b/components/scheduler/templates/resource-grouping-header.md
@@ -15,7 +15,7 @@ You can use the `SchedulerResourceGroupHeaderTemplate` to customize the renderin
 The `SchedulerResourceGroupHeaderTemplate`:
 * Is invoked for each resource when the Scheduler is configured to have resources and grouping.
 * Applies in both horizontal and vertical grouping.
-* Can be defined individually for each [Scheduler views]({%slug scheduler-views-overview%}).
+* Can be defined individually for each [Scheduler view]({%slug scheduler-views-overview%}).
 
 The `context` of the template is a `SchedulerResourceGroupHeaderTemplateContext` object that contains:
 

--- a/components/scheduler/templates/slot.md
+++ b/components/scheduler/templates/slot.md
@@ -310,5 +310,5 @@ The `context` of the template is a `SchedulerSlotTemplateContext` object that co
 
 ## See Also
 
- * [Live Demo: Scheduler Templates](https://demos.telerik.com/blazor-ui/scheduler/slot-templates)
+ * [Live Demo: Scheduler Templates](https://demos.telerik.com/blazor-ui/scheduler/templates)
 


### PR DESCRIPTION
Related to:
https://github.com/telerik/blazor/issues/10094#issuecomment-2360771870 - In general, while we still support NET6 we won't be able to expose the SchedulerResourceGroupHeaderTemplate on the root level of the Scheduler
and
https://github.com/telerik/blazor/pull/10098#issuecomment-2360393620 - The demos won't be separated for each template, so we need to update the references
