### PR TITLE
chore(TreeList): remove invalid link

### DIFF
--- a/components/treelist/filter/searchbox.md
+++ b/components/treelist/filter/searchbox.md
@@ -260,7 +260,6 @@ The example below demonstrates all SearchBox settings in action, and also how to
 * [Live Demo: TreeList SearchBox](https://demos.telerik.com/blazor-ui/treelist/searchbox)
 * [Format or Bold Search Results in the TreeList]({%slug grid-kb-search-highlight-results%})
 * [Search the TreeList in Numeric and Date Model Fields]({%slug grid-kb-search-numeric-fields%})
-* [Search the TreeList in Hidden Fields]({%slug grid-kb-search-in-hidden-fields%})
 * [Search the TreeList with a `StartsWith` operator]({%slug grid-kb-search-startswith%})
 * [Search the TreeList on Button Click]({%slug grid-kb-search-button-click%})
 * [Treelist Filtering Overview]({%slug treelist-filtering%})


### PR DESCRIPTION
Currently, we do not expose the OnRead event for the TreeList, so the suggested approach in the KB article is invalid.

Triggered by: https://supportheroes.telerik.com/ticket/1667663
