### PR TITLE
chore(Grid): update onread examples due to a latest changes

### DIFF
--- a/components/grid/grouping/load-on-demand.md
+++ b/components/grid/grouping/load-on-demand.md
@@ -161,11 +161,11 @@ Scroll through the groups or expand them to load their data on demand
 
         if (args.Request.Groups.Count > 0)
         {
-            args.Data = result.GroupedData.Cast<object>().ToList();
+            args.Data = result.GroupedData;
         }
         else
         {
-            args.Data = result.CurrentPageData.Cast<object>().ToList();
+            args.Data = result.CurrentPageData;
         }
 
         args.Total = result.TotalItemCount;

--- a/components/grid/manual-operations.md
+++ b/components/grid/manual-operations.md
@@ -232,7 +232,6 @@ This sample shows how to set up the grid to use grouping with manual data source
 @code {
     public List<Employee> SourceData { get; set; }
 
-    // Handling grouping happens here - by casting the DataSourceResult.Data to objects
     protected async Task ReadItems(GridReadEventArgs args)
     {
         // in this example, we use the Telerik extension methods to shape the data
@@ -243,7 +242,7 @@ This sample shows how to set up the grid to use grouping with manual data source
         // to work with grouping, the grid data needs to be an IEnumerable<object>
         // because grouped data has a different shape than non-grouped data
         // and this is, generally, hidden from you by the grid, but now it cannot be
-        args.Data = datasourceResult.Data.Cast<object>().ToList();
+        args.Data = datasourceResult.Data;
 
         args.Total = datasourceResult.Total;
         args.AggregateResults = datasourceResult.AggregateResults;

--- a/knowledge-base/grid-custom-grouping-order.md
+++ b/knowledge-base/grid-custom-grouping-order.md
@@ -95,7 +95,7 @@ To achieve custom grouping order in the Telerik Grid for Blazor, follow these st
 			List<string> customOrder = new List<string> { "Text D", "Text A", "Text C", "Text B" };
 			groups = groups.OrderBy(group => customOrder.IndexOf(group.Key.ToString())).ToList();
 
-			args.Data = groups.Cast<object>().ToList();
+			args.Data = groups;
 		}
 		else
 		{
@@ -104,7 +104,7 @@ To achieve custom grouping order in the Telerik Grid for Blazor, follow these st
 								.OrderBy(Text => GetCustomOrderIndex(Text.S1))
 								.ToList();
 
-			args.Data = orderedData.Cast<object>().ToList();
+			args.Data = orderedData;
 		}
 
 		args.Total = datasourceResult.Total;

--- a/upgrade/breaking-changes/7-0-0.md
+++ b/upgrade/breaking-changes/7-0-0.md
@@ -43,7 +43,7 @@ The obsolete `ClearButton` parameter is removed. Use `ShowClearButton` instead.
 * The obsolete `AutoFitColumn()` method is removed. [Use `AutoFitColumnAsync()`]({%slug components/grid/columns/resize%}#autofit-columns) instead.
 * The obsolete `AutoFitColumns()` method is removed. Use `AutoFitColumnsAsync()` instead.
 * The obsolete `AutoFitAllColumns()` method is removed. Use `AutoFitAllColumnsAsync()` instead.
-* When using grouping and `OnRead`, casting the `DataSourceResult.Data` to a list of objects (`.Cast<object>().ToList();`) is no longer needed.
+* When using [grouping and `OnRead`]({%slug components/grid/manual-operations%}#grouping-with-onread), casting `DataSourceResult.Data` to a list of objects (`.Cast<object>()`) is no longer needed.
 
 ## TextArea
 

--- a/upgrade/breaking-changes/7-0-0.md
+++ b/upgrade/breaking-changes/7-0-0.md
@@ -43,6 +43,7 @@ The obsolete `ClearButton` parameter is removed. Use `ShowClearButton` instead.
 * The obsolete `AutoFitColumn()` method is removed. [Use `AutoFitColumnAsync()`]({%slug components/grid/columns/resize%}#autofit-columns) instead.
 * The obsolete `AutoFitColumns()` method is removed. Use `AutoFitColumnsAsync()` instead.
 * The obsolete `AutoFitAllColumns()` method is removed. Use `AutoFitAllColumnsAsync()` instead.
+* When using grouping and `OnRead`, casting the `DataSourceResult.Data` to a list of objects (`.Cast<object>().ToList();`) is no longer needed.
 
 ## TextArea
 


### PR DESCRIPTION
The need for the update comes from the fix of [this bug](https://github.com/telerik/blazor/pull/10265). 