### PR TITLE
chore(Badge): fix cutout badge

### DIFF
--- a/components/badge/overview.md
+++ b/components/badge/overview.md
@@ -24,8 +24,8 @@ The Badge comes with built-in customization features that allow the developer to
 
 ````CSHTML
 <TelerikButton>
-    <TelerikBadge>12</TelerikBadge>
-   Notifications
+    <TelerikBadge VerticalAlign="@BadgeVerticalAlign.Bottom">12</TelerikBadge>
+    Notifications
 </TelerikButton>
 ````
 


### PR DESCRIPTION
The Badge in this example currently looks like this in the integrated REPL: 
<img width="115" alt="image" src="https://github.com/user-attachments/assets/03422c3d-ac65-49a5-b636-7f19ee884e81">

