### PR TITLE
docs(Window): add kb for programmatic center of the window

### DIFF
--- a/knowledge-base/window-center-programmatically.md
+++ b/knowledge-base/window-center-programmatically.md
@@ -1,0 +1,78 @@
+---
+title: How To Center Window Programmatically
+description: Learn how to center a Telerik Window programmatically by using the Top and Left parameters.
+type: how-to
+page_title: How To Center Window Programmatically
+slug: window-kb-center-programmatically
+tags: window, center, position, blazor,
+res_type: kb
+ticketid:
+---
+
+## Environment
+<table>
+	<tbody>
+		<tr>
+			<td>Product</td>
+			<td>Window for Blazor</td>
+		</tr>
+	</tbody>
+</table>
+
+## Description
+
+This knowledge base article answers the following questions:
+
+* How can I programmatically center a Telerik Window?
+* How do I reset a Telerik Window to its default position?
+* How can I position a Telerik Window in the center of the viewport?
+* How do I dynamically adjust the Telerik Window position?
+
+## Solution
+
+To center a Telerik Window programmatically, follow these steps:
+
+1. Use [`Top` and `Left` parameters](slug:components/window/position#top-and-left) – These parameters define the Window position on the screen.
+2. Reset `Top` and `Left` parameters to center the Window – Setting them to `string.Empty` allows automatic centering.
+3. Refresh the Window using component reference – Calling `WindowRef?.Refresh();` re-renders the Window with the new position.
+
+>caption Telerik Blazor Window Centered Programmatically
+
+````RAZOR
+@if (!IsWindowVisible)
+{
+    <TelerikButton OnClick="@(() => IsWindowVisible = !IsWindowVisible)">Open Window</TelerikButton>
+}
+<TelerikButton OnClick="@CenterWindow">Center Window</TelerikButton>
+
+<TelerikWindow @bind-Visible="@IsWindowVisible"
+               @bind-Top="@Top"
+               @bind-Left="@Left"
+               Width="200px"
+               Height="200px"
+               @ref="WindowRef">
+    <WindowTitle>
+        Window Title
+    </WindowTitle>
+    <WindowActions>
+        <WindowAction Name="Close" />
+    </WindowActions>
+</TelerikWindow>
+
+@code {
+    private TelerikWindow? WindowRef { get; set; }
+    private bool IsWindowVisible { get; set; } = true;
+    private string Top { get; set; } = "30%";
+    private string Left { get; set; } = "60%";
+
+    private void CenterWindow()
+    {
+        Top = Left = string.Empty;
+        WindowRef?.Refresh();
+    }
+}
+````
+
+## See Also
+- [Window Position](slug:components/window/position)
+- [Telerik Window for Blazor - Overview](slug:window-overview)

--- a/knowledge-base/window-center-programmatically.md
+++ b/knowledge-base/window-center-programmatically.md
@@ -32,9 +32,9 @@ This knowledge base article answers the following questions:
 
 To center a Telerik Window programmatically, follow these steps:
 
-1. Bind the [`Top` and `Left` parameters](slug:components/window/position#top-and-left) using `@bind-Top` and `@bind-Left` to control the Window position dynamically. Set their default values to specific ones (e.g., `Top="30%"`, `Left="60%"`) to position the Window where you want it to appear initially.
-2. Set both parameters to `string.Empty` to reset the Window position. This will ensure that, the component automatically repositions itself to the center of the current viewport.
-3. Refresh the Window using component reference – Calling [`WindowRef?.Refresh();`](slug:window-overview#window-reference-and-methods) re-renders the Window with the new position.
+1. Set the [`Top` and `Left` parameters](slug:components/window/position#top-and-left) using `@bind-Top` and `@bind-Left` or the [`TopChanged` and `LeftChanged` events](slug:window-events#leftchanged-and-topchanged).
+2. Set both parameters to `string.Empty` to center the Window initially or any time afterwards.
+3. [Call the `Refresh()` method of the Window component instance](slug:window-overview#window-reference-and-methods) to re-render the Window at the new position.
 
 >caption Center the Telerik Blazor Window Programmatically
 

--- a/knowledge-base/window-center-programmatically.md
+++ b/knowledge-base/window-center-programmatically.md
@@ -32,20 +32,14 @@ This knowledge base article answers the following questions:
 
 To center a Telerik Window programmatically, follow these steps:
 
-1. Use [`Top` and `Left` parameters](slug:components/window/position#top-and-left) – These parameters define the Window position on the screen.
-2. Reset `Top` and `Left` parameters to center the Window – Setting them to `string.Empty` allows automatic centering.
-3. Refresh the Window using component reference – Calling `WindowRef?.Refresh();` re-renders the Window with the new position.
+1. Bind the [`Top` and `Left` parameters](slug:components/window/position#top-and-left) using `@bind-Top` and `@bind-Left` to control the Window position dynamically. Set their default values to specific ones (e.g., `Top="30%"`, `Left="60%"`) to position the Window where you want it to appear initially.
+2. Set both parameters to `string.Empty` to reset the Window position. This will ensure that, the component automatically repositions itself to the center of the current viewport.
+3. Refresh the Window using component reference – Calling [`WindowRef?.Refresh();`](slug:window-overview#window-reference-and-methods) re-renders the Window with the new position.
 
->caption Telerik Blazor Window Centered Programmatically
+>caption Center the Telerik Blazor Window Programmatically
 
 ````RAZOR
-@if (!IsWindowVisible)
-{
-    <TelerikButton OnClick="@(() => IsWindowVisible = !IsWindowVisible)">Open Window</TelerikButton>
-}
-<TelerikButton OnClick="@CenterWindow">Center Window</TelerikButton>
-
-<TelerikWindow @bind-Visible="@IsWindowVisible"
+<TelerikWindow Visible="true"
                @bind-Top="@Top"
                @bind-Left="@Left"
                Width="200px"
@@ -54,14 +48,13 @@ To center a Telerik Window programmatically, follow these steps:
     <WindowTitle>
         Window Title
     </WindowTitle>
-    <WindowActions>
-        <WindowAction Name="Close" />
-    </WindowActions>
+    <WindowContent>
+        <TelerikButton OnClick="@CenterWindow">Center Window</TelerikButton>
+    </WindowContent>
 </TelerikWindow>
 
 @code {
     private TelerikWindow? WindowRef { get; set; }
-    private bool IsWindowVisible { get; set; } = true;
     private string Top { get; set; } = "30%";
     private string Left { get; set; } = "60%";
 

--- a/knowledge-base/window-center-programmatically.md
+++ b/knowledge-base/window-center-programmatically.md
@@ -55,8 +55,8 @@ To center a Telerik Window programmatically, follow these steps:
 
 @code {
     private TelerikWindow? WindowRef { get; set; }
-    private string Top { get; set; } = "30%";
-    private string Left { get; set; } = "60%";
+    private string Top { get; set; } = "10%";
+    private string Left { get; set; } = "10%";
 
     private void CenterWindow()
     {


### PR DESCRIPTION
Related to: https://github.com/telerik/blazor/issues/8956

Once we deprecate the Centered parameter of the Window, will link this KB to Window Position documentation.
