### PR TITLE
Update observeTarget to retain parameter passing

### DIFF
--- a/knowledge-base/grid-autofit-columns.md
+++ b/knowledge-base/grid-autofit-columns.md
@@ -166,7 +166,7 @@ function observeTarget(dotNetObj, gridClass) {
     dotNetInstance = dotNetObj;
  
     if (!result || !window.DotNet) {
-        window.setTimeout(observeTarget, 500);
+        window.setTimeout(observeTarget, 500, dotNetObj, gridClass);
         return;
     }
     observer.observe(result, options);


### PR DESCRIPTION
If observeTarget is called from setTimeout, the original parameters to the call are lost and dotNetObj and gridClass are undefined on subsequent invocations.

Note to external contributors: make sure to sign our Contribution License Agreement (CLA) for Blazor UI first:

https://forms.office.com/Pages/ResponsePage.aspx?id=Z2om2-DLJk2uGtBYH-A1NbWxVqugKN5DvVp8I-1AgOBURFBVSkwyMlA1TkFDVFdMNU1aM1o1UlZQOC4u
