### PR TITLE
Update video-onboarding.md

### DIFF
--- a/getting-started/video-onboarding.md
+++ b/getting-started/video-onboarding.md
@@ -11,7 +11,7 @@ position: 30
 
 # Video Onboarding
 
-All users with an active trial or commercial license have access to a [Telerik UI for Blazor getting started video course](https://www.youtube.com/playlist?list=PLvmaC-XMqeBYOAIwNousFCG2rib4fcdvz).
+All users have access to a [Telerik UI for Blazor getting started video course](https://www.youtube.com/playlist?list=PLvmaC-XMqeBYOAIwNousFCG2rib4fcdvz).
 The training course is developed to help you get started with the Telerik UI for Blazor components and features. It aims to put you in the shoes of an engineer who adds new features to an existing application.
 
 {% if site.has_cta_panels == true %}


### PR DESCRIPTION
The text implied that users required a license to view the videos. Now that they're hosted on YouTube, anyone can view them regardless of license.

Note to external contributors: make sure to sign our Contribution License Agreement (CLA) for Blazor UI first:

https://forms.office.com/Pages/ResponsePage.aspx?id=Z2om2-DLJk2uGtBYH-A1NbWxVqugKN5DvVp8I-1AgOBURFBVSkwyMlA1TkFDVFdMNU1aM1o1UlZQOC4u
