### PR TITLE
docs(ListBox): Add multiple item drag-and-drop to example

### DIFF
--- a/components/listbox/drag-drop.md
+++ b/components/listbox/drag-drop.md
@@ -8,6 +8,7 @@ published: True
 position: 40
 components: ["listbox"]
 ---
+
 # ListBox Item Drag and Drop
 
 The Telerik Blazor ListBox allows users to drag and drop items within the same component instance or across different instances. This is a more flexible alternative to [reordering](slug:listbox-overview#creating-blazor-listbox) or [moving ListBox items](slug:listbox-connect) with toolbar buttons. As a result, dragging and dropping can be a lot faster and convenient to users when the number of related ListBoxes is three or more.
@@ -20,6 +21,7 @@ To enable drag and drop between ListBox components:
 1. Set `Draggable="true"` to all of them.
 1. Set [`DropSources` to the `Id` values](slug:listbox-overview#listbox-parameters) of the permitted source ListBoxes.
 1. Subscribe to the [`OnDrop` event](slug:listbox-events#ondrop) of each ListBox that users can drag items from. The `OnDrop` event always fires from the source (origin) ListBox instance.
+1. Decide if you want to drag and drop the single item from the `args.Items` event argument or the full current selection.
 1. [`Rebind()`](slug:listbox-overview#listbox-reference-and-methods) each ListBox after making programmatic changes to its `Data`.
 
 
@@ -28,7 +30,12 @@ To enable drag and drop between ListBox components:
 >caption Using ListBox drag and drop
 
 ````RAZOR
-@* Drag and drop items between ListBoxes *@
+<p>
+    <label>
+        <TelerikCheckBox @bind-Value="@EnableMultipleItemDrop" />
+        Drag and Drop All Selected Items
+    </label>
+</p>
 
 <TelerikListBox @ref="@ListBoxRef1"
                 Data="@ListBoxData1"
@@ -94,21 +101,34 @@ To enable drag and drop between ListBox components:
     private IEnumerable<ListBoxModel> ListBoxSelectedItems2 { get; set; } = new List<ListBoxModel>();
     private IEnumerable<ListBoxModel> ListBoxSelectedItems3 { get; set; } = new List<ListBoxModel>();
 
+    private bool EnableMultipleItemDrop { get; set; } = true;
+
     private void OnListBoxDrop(
         ListBoxDropEventArgs<ListBoxModel> args,
         string sourceListBoxId,
         List<ListBoxModel> sourceData)
     {
-        var destinationIndex = args.DestinationIndex ?? 0;
-        var destinationData = GetListBoxDataFromId(args.DestinationListBoxId);
+        int destinationIndex = args.DestinationIndex ?? 0;
+        List<ListBoxModel> destinationData = GetListBoxDataFromId(args.DestinationListBoxId);
+        IEnumerable<ListBoxModel> selectedItems = GetSelectedItemsFromId(sourceListBoxId);
+        bool handleSelection = ShouldHandleMultipleItemDrop(selectedItems, args.Items);
+
+        List<ListBoxModel> itemsToHandle = handleSelection ? selectedItems.ToList() : args.Items;
 
         if (args.DestinationListBoxId == sourceListBoxId)
         {
-            ReorderItems(args.Items, sourceData, destinationIndex);
+            int sourceIndex = sourceData.IndexOf(args.Items.First());
+
+            if (sourceIndex == destinationIndex)
+            {
+                return;
+            }
+
+            ReorderItems(itemsToHandle, sourceData, destinationIndex);
         }
         else
         {
-            MoveItems(args.Items, sourceData, destinationData, destinationIndex);
+            MoveItems(itemsToHandle, sourceData, destinationData, destinationIndex);
         }
 
         ListBoxRef1.Rebind();
@@ -139,7 +159,7 @@ To enable drag and drop between ListBox components:
         List<ListBoxModel> destinationData,
         int destinationIndex)
     {
-        foreach (var item in items)
+        foreach (ListBoxModel item in items)
         {
             sourceData.RemoveAll(x => items.Any(y => y.Id == x.Id));
 
@@ -156,7 +176,7 @@ To enable drag and drop between ListBox components:
 
     private List<ListBoxModel> GetListBoxDataFromId(string listBoxId)
     {
-        var collection = new List<ListBoxModel>();
+        List<ListBoxModel> collection = new();
 
         switch (listBoxId)
         {
@@ -174,6 +194,33 @@ To enable drag and drop between ListBox components:
         }
 
         return collection;
+    }
+
+    private IEnumerable<ListBoxModel> GetSelectedItemsFromId(string listBoxId)
+    {
+        IEnumerable<ListBoxModel> collection = Enumerable.Empty<ListBoxModel>();
+
+        switch (listBoxId)
+        {
+            case ListBoxId1:
+                collection = ListBoxSelectedItems1;
+                break;
+            case ListBoxId2:
+                collection = ListBoxSelectedItems2;
+                break;
+            case ListBoxId3:
+                collection = ListBoxSelectedItems3;
+                break;
+            default:
+                break;
+        }
+
+        return collection;
+    }
+
+    private bool ShouldHandleMultipleItemDrop(IEnumerable<ListBoxModel> selectedItems, List<ListBoxModel> droppedItems)
+    {
+        return EnableMultipleItemDrop && selectedItems is not null && selectedItems.Count() > 0 && selectedItems.Contains(droppedItems.First());
     }
 
     protected override void OnInitialized()


### PR DESCRIPTION
Related to 1713355  and https://feedback.telerik.com/blazor/1637333-allow-drag-and-drop-of-multiple-selected-items-from-one-listbox-to-another