### PR TITLE
[WIP] Migrate DPL namespace references in docs

### DIFF
--- a/knowledge-base/editor-convert-to-plain-text.md
+++ b/knowledge-base/editor-convert-to-plain-text.md
@@ -34,9 +34,9 @@ Here are the required steps:
 
 1. Add the [`Telerik.Documents.Core` and `Telerik.Documents.Flow`](slug:dpl-in-blazor) NuGet packages to your project.
 1. Import the required namespaces:
-    * `Telerik.Windows.Documents.Flow.FormatProviders.Html`
-    * `Telerik.Windows.Documents.Flow.FormatProviders.Txt`
-    * `Telerik.Windows.Documents.Flow.Model`
+    * `Telerik.Documents.Flow.FormatProviders.Html`
+    * `Telerik.Documents.Flow.FormatProviders.Txt`
+    * `Telerik.Documents.Flow.Model`
 1. Create an [`HtmlFormatProvider`](https://docs.telerik.com/devtools/document-processing/libraries/radwordsprocessing/formats-and-conversion/html/htmlformatprovider) instance.
 1. Use the HTML provider's **`Import`** method to create a `RadFlowDocument` from the Editor's HTML value.
 1. Create a [`TxtFormatProvider`](https://docs.telerik.com/devtools/document-processing/libraries/radwordsprocessing/formats-and-conversion/plain-text/txt-txtformatprovider) instance.
@@ -49,11 +49,11 @@ To export to another format, use the corresponding namespace and format provider
 <div class="skip-repl"></div>
 ````RAZOR
 @*TxtFormatProvider*@
-@using Telerik.Windows.Documents.Flow.FormatProviders.Txt;
+@using Telerik.Documents.Flow.FormatProviders.Txt;
 @*HtmlFormatProvider*@
-@using Telerik.Windows.Documents.Flow.FormatProviders.Html;
+@using Telerik.Documents.Flow.FormatProviders.Html;
 @*RadFlowDocument*@
-@using Telerik.Windows.Documents.Flow.Model;
+@using Telerik.Documents.Flow.Model;
 
 <TelerikEditor @bind-Value="@HtmlValue" />
 

--- a/knowledge-base/grid-csv-export-change-field-delimiter.md
+++ b/knowledge-base/grid-csv-export-change-field-delimiter.md
@@ -47,8 +47,8 @@ To change the CSV value delimiter:
 1. Pass that `MemoryStream` to the `Stream` property of the `GridAfterCsvExportEventArgs`, so that the modifications can be saved to the actual exported file.
 
 ````RAZOR.skip-repl
-@using Telerik.Windows.Documents.Spreadsheet.FormatProviders.TextBased.Csv
-@using Telerik.Windows.Documents.Spreadsheet.Model
+@using Telerik.Documents.Spreadsheet.FormatProviders.TextBased.Csv
+@using Telerik.Documents.Spreadsheet.Model
 @using System.IO
 
 <TelerikGrid Data="@GridData"
@@ -144,4 +144,3 @@ To change the CSV value delimiter:
 * [Custom cell formatting of the exported file with RadSpreadProcessing](slug:grid-kb-custom-cell-formatting-with-radspreadprocessing)
 * [Configure Document Processing Libraries](slug:getting-started-vs-integration-dpl)
 * [Grid Overview](slug:grid-overview)
-

--- a/knowledge-base/grid-custom-cell-formatting-with-radspreadprocessing.md
+++ b/knowledge-base/grid-custom-cell-formatting-with-radspreadprocessing.md
@@ -61,10 +61,10 @@ To customize the cell format of the exported file before it reaches the client, 
 
 @using Telerik.Documents.Media
 @using Telerik.Documents.Common.Model
-@using Telerik.Windows.Documents.Spreadsheet.FormatProviders
-@using Telerik.Windows.Documents.Spreadsheet.FormatProviders.OpenXml.Xlsx
-@using Telerik.Windows.Documents.Spreadsheet.FormatProviders.TextBased.Csv
-@using Telerik.Windows.Documents.Spreadsheet.Model
+@using Telerik.Documents.Spreadsheet.FormatProviders
+@using Telerik.Documents.Spreadsheet.FormatProviders.OpenXml.Xlsx
+@using Telerik.Documents.Spreadsheet.FormatProviders.TextBased.Csv
+@using Telerik.Documents.Spreadsheet.Model
 
 <TelerikGrid Data="@GridData" Pageable="true">
     <GridToolBarTemplate>

--- a/knowledge-base/grid-load-cyrillic-fonts-in-pdf-export.md
+++ b/knowledge-base/grid-load-cyrillic-fonts-in-pdf-export.md
@@ -38,8 +38,8 @@ The snippet below shows how to load an example Cyrillic font, so the Grid can pr
 ````RAZOR
 @using System.Globalization
 @using Telerik.Documents.Core.Fonts
-@using Telerik.Windows.Documents.Extensibility
-@using Telerik.Windows.Documents.Core.Fonts
+@using Telerik.Documents.Extensibility
+@using Telerik.Documents.Core.Fonts
 
 @inject IWebHostEnvironment HostEnvironment
 

--- a/knowledge-base/grid-number-formatting-of-the-csv-export.md
+++ b/knowledge-base/grid-number-formatting-of-the-csv-export.md
@@ -42,7 +42,7 @@ To format numeric and date cells of the exported file before it reaches the clie
 
 1. Use a `CsvFormatProvider` instance to [import the new `MemoryStream` in a `workbook`](https://docs.telerik.com/devtools/document-processing/libraries/radspreadprocessing/formats-and-conversion/csv/csvformatprovider#import).
 
-1. Create an instance of [CellValueFormat](https://docs.telerik.com/devtools/document-processing/api/telerik.windows.documents.spreadsheet.model.cellvalueformat) for each desired format you want to use. [Read more for the available numeric formats...](https://docs.telerik.com/devtools/document-processing/libraries/radspreadprocessing/features/number-formats).
+1. Create an instance of [CellValueFormat](https://docs.telerik.com/devtools/document-processing/api/telerik.documents.spreadsheet.model.cellvalueformat) for each desired format you want to use. [Read more for the available numeric formats...](https://docs.telerik.com/devtools/document-processing/libraries/radspreadprocessing/features/number-formats).
 
 1. Select the desired cells - you can create a [CellSelection](https://docs.telerik.com/devtools/document-processing/libraries/radspreadprocessing/working-with-cells/accessing-cells-of-worksheet) or target whole columns by their index.
 
@@ -55,8 +55,8 @@ To format numeric and date cells of the exported file before it reaches the clie
 ````RAZOR.skip-repl
 @*Use RadSpreadProcessing to format numeric data in the exported CSV file*@
 
-@using Telerik.Windows.Documents.Spreadsheet.FormatProviders.TextBased.Csv
-@using Telerik.Windows.Documents.Spreadsheet.Model
+@using Telerik.Documents.Spreadsheet.FormatProviders.TextBased.Csv
+@using Telerik.Documents.Spreadsheet.Model
 @using System.IO
 
 <TelerikGrid Data="@GridData" Pageable="true">

--- a/knowledge-base/grid-remove-aggregate-labels-in-excel-footer.md
+++ b/knowledge-base/grid-remove-aggregate-labels-in-excel-footer.md
@@ -52,8 +52,8 @@ This KB article answers the following questions:
 >caption Remove aggregate labels from footer cells in the exported Excel file by the Grid
 
 ````RAZOR.skip-repl
-@using Telerik.Windows.Documents.Spreadsheet.FormatProviders.OpenXml.Xlsx
-@using Telerik.Windows.Documents.Spreadsheet.Model
+@using Telerik.Documents.Spreadsheet.FormatProviders.OpenXml.Xlsx
+@using Telerik.Documents.Spreadsheet.Model
 
 @using Telerik.Blazor.Services
 @inject ITelerikStringLocalizer TelerikLocalizer

--- a/knowledge-base/pdfviewer-sign-pdfs.md
+++ b/knowledge-base/pdfviewer-sign-pdfs.md
@@ -96,7 +96,7 @@ The PdfViewer does not currently have the capability to manage digital signature
 
         // The Signature object is added to a signature field, so we can add a visualization to it.
         var signatureField = new SignatureField(signatureName);
-        signatureField.Signature = new Telerik.Windows.Documents.Fixed.Model.DigitalSignatures.Signature(certificate);
+        signatureField.Signature = new Telerik.Documents.Fixed.Model.DigitalSignatures.Signature(certificate);
 
         // Close the local cert store now that you're done
         x509Store.Close();
@@ -110,7 +110,7 @@ The PdfViewer does not currently have the capability to manage digital signature
         RadFixedPage page = document.Pages.AddPage();
 
         // This is the Form XObject element that represents the contents of the signature field.
-        var form = new Telerik.Windows.Documents.Fixed.Model.Objects.Form
+        var form = new Telerik.Documents.Fixed.Model.Objects.Form
         {
             FormSource = new FormSource { Size = new Size(220, 220) }
         };
@@ -136,7 +136,7 @@ The PdfViewer does not currently have the capability to manage digital signature
         editor.DrawForm(form.FormSource);
         document.AcroForm.FormFields.Add(signatureField);
         widget.RecalculateContent();
-        widget.AppearanceCharacteristics.Background = new Telerik.Windows.Documents.Fixed.Model.ColorSpaces.RgbColor(255, 0, 0);
+        widget.AppearanceCharacteristics.Background = new Telerik.Documents.Fixed.Model.ColorSpaces.RgbColor(255, 0, 0);
 
         // **** PHASE 4 - EXPORT DOCUMENT **** //
         byte[] signedDocBytes = new PdfFormatProvider().Export(document);

--- a/knowledge-base/spreadsheet-bind-to-json-ienumerable-list-collection.md
+++ b/knowledge-base/spreadsheet-bind-to-json-ienumerable-list-collection.md
@@ -47,9 +47,9 @@ The approach requires [Telerik Document Processing](slug:dpl-in-blazor) to creat
 @using System.Reflection
 
 @using Telerik.Documents.Common.Model
-@using Telerik.Windows.Documents.Spreadsheet.FormatProviders
-@using Telerik.Windows.Documents.Spreadsheet.FormatProviders.OpenXml.Xlsx
-@using Telerik.Windows.Documents.Spreadsheet.Model
+@using Telerik.Documents.Spreadsheet.FormatProviders
+@using Telerik.Documents.Spreadsheet.FormatProviders.OpenXml.Xlsx
+@using Telerik.Documents.Spreadsheet.Model
 
 <h1>Bind Spreadsheet to <code>IEnumerable</code></h1>
 

--- a/knowledge-base/spreadsheet-get-cell-values.md
+++ b/knowledge-base/spreadsheet-get-cell-values.md
@@ -46,18 +46,18 @@ This KB article answers the following questions:
 1. [Iterate the cell range](https://docs.telerik.com/devtools/document-processing/libraries/radspreadprocessing/working-with-cells/iterating-used-cells).
 1. Get each cell value (`ICellValue` object), cell value type (`CellValueType` object), and cell format (`CellValueFormat` object) to know more about the cell content.
 1. Use `ICellValue.RawValue` or `ICellValue.GetResultValueAsString(CellValueFormat cellFormat)` to obtain the actual cell content.
-1. [Excel stores dates as numbers](https://docs.telerik.com/devtools/document-processing/libraries/radspreadprocessing/working-with-cells/cell-value-types). Use [`FormatHelper.ConvertDoubleToDateTime(Convert.ToDouble(ICellValue.RawValue))`](https://docs.telerik.com/devtools/document-processing/api/telerik.windows.documents.spreadsheet.formatting.formathelper) to retrieve any `DateTime` values.
+1. [Excel stores dates as numbers](https://docs.telerik.com/devtools/document-processing/libraries/radspreadprocessing/working-with-cells/cell-value-types). Use [`FormatHelper.ConvertDoubleToDateTime(Convert.ToDouble(ICellValue.RawValue))`](https://docs.telerik.com/devtools/document-processing/api/telerik.documents.spreadsheet.formatting.formathelper) to retrieve any `DateTime` values.
 
 >caption Iterate the Spreadsheet cells and get their values
 
 <div class="skip-repl"></div>
 
 ````RAZOR
-@using Telerik.Windows.Documents.Spreadsheet.FormatProviders
-@using Telerik.Windows.Documents.Spreadsheet.FormatProviders.OpenXml.Xlsx
-@using Telerik.Windows.Documents.Spreadsheet.Formatting
-@using Telerik.Windows.Documents.Spreadsheet.Formatting.FormatStrings
-@using Telerik.Windows.Documents.Spreadsheet.Model
+@using Telerik.Documents.Spreadsheet.FormatProviders
+@using Telerik.Documents.Spreadsheet.FormatProviders.OpenXml.Xlsx
+@using Telerik.Documents.Spreadsheet.Formatting
+@using Telerik.Documents.Spreadsheet.Formatting.FormatStrings
+@using Telerik.Documents.Spreadsheet.Model
 
 <p>
     <TelerikButton ThemeColor="@ThemeConstants.Button.ThemeColor.Primary"


### PR DESCRIPTION
## Summary
- update docs snippets and DPL API links from `Telerik.Windows.*` to `Telerik.Documents.*`
- align KB content with the new DPL namespace naming