### PR TITLE
Fix code snippet markdown formatting

### DIFF
--- a/components/colorpicker/overview.md
+++ b/components/colorpicker/overview.md
@@ -24,7 +24,7 @@ Practically, the ColorPicker is identical to the [Telerik UI for Blazor FlatColo
 
 >caption A basic ColorPicker with two-way value binding
 
-```CSHTML
+````CSHTML
 <TelerikColorPicker @bind-Value="@MyColor" ValueFormat="ColorFormat.Hex"/>
 
 <p>Selected color: <span style="color: @MyColor">@MyColor</span></p>
@@ -32,7 +32,7 @@ Practically, the ColorPicker is identical to the [Telerik UI for Blazor FlatColo
 @code {
     string MyColor { get; set; }
 }
-```
+````
 
 ## Views
 

--- a/components/editor/prosemirror-plugins.md
+++ b/components/editor/prosemirror-plugins.md
@@ -48,7 +48,7 @@ The Editor will call this function and will pass an argument object that contain
 
 >caption Adding a Placeholder Plugin
 
-```CSHTML
+````CSHTML
 @using Telerik.Blazor.Components.Editor
 @inject IJSRuntime js
 
@@ -128,7 +128,7 @@ The Editor will call this function and will pass an argument object that contain
         head.appendChild(style);
     };
 </script>
-```
+````
 
 ## See Also
 

--- a/components/fileselect/initial-files.md
+++ b/components/fileselect/initial-files.md
@@ -17,7 +17,7 @@ To configure the initially displayed files, use the `Files` parameter of the Fil
 
 >caption Display initial files in FileSelect's list.
 
-```CSHTML
+````CSHTML
 
 <TelerikFileSelect Files="@InitialFiles" />
 
@@ -30,7 +30,7 @@ To configure the initially displayed files, use the `Files` parameter of the Fil
     };
 }
 
-```
+````
 
 ## Persist Selected Files
 
@@ -40,7 +40,7 @@ The Initial Files feature of the FileSelect allows you to save a list of files t
 
 >caption How to load files and display them initially in the FileSelect
 
-```CSHTML
+````CSHTML
 
 @using System.IO;
 
@@ -77,7 +77,7 @@ The Initial Files feature of the FileSelect allows you to save a list of files t
     }
 }
 
-```
+````
 
 
 ## See Also

--- a/components/fileselect/templates.md
+++ b/components/fileselect/templates.md
@@ -23,14 +23,14 @@ The `SelectFilesButtonTemplate` allows you to modify the **Select Files...** but
 
 >caption Using FileSelect SelectFilesButtonTemplate
 
-```CSHTML
+````CSHTML
 <TelerikFileSelect>
     <SelectFilesButtonTemplate>
         <TelerikSvgIcon Icon="@SvgIcon.Upload" />
         Click to Select Files for Upload
     </SelectFilesButtonTemplate>
 </TelerikFileSelect>
-```
+````
 
 ## FileTemplate
 
@@ -42,7 +42,7 @@ The example below demonstrates how to use the `RemoveFileAsync()` method to remo
 
 >caption Using FileSelect FileTemplate
 
-```CSHTML
+````CSHTML
 <TelerikFileSelect @ref="@FileSelectRef" Files="@InitialFiles">
     <FileTemplate Context="fileContext">
         <div class="custom-file-item">
@@ -106,7 +106,7 @@ The example below demonstrates how to use the `RemoveFileAsync()` method to remo
         FileSelectRef.RemoveFile(fileId);
     }
 }
-```
+````
 
 ## FileInfoTemplate
 
@@ -116,7 +116,7 @@ The `FileInfoTemplate` exposes a `context` of type `FileInfoTemplateContext` tha
 
 >caption Using FileSelect FileInfoTemplate
 
-```CSHTML
+````CSHTML
 <TelerikFileSelect Files="@InitialFiles">
     <FileInfoTemplate Context="fileContext">
         <strong>File Name:</strong> @fileContext.File.Name <br />
@@ -130,7 +130,7 @@ The `FileInfoTemplate` exposes a `context` of type `FileInfoTemplateContext` tha
         new FileSelectFileInfo(){ Id="1", Name="Report", Extension=".pdf", Size = 1024 * 1024 * 2 }
     };
 }
-```
+````
 
 ## See Also
 

--- a/components/gantt/gantt-tree/templates/editor.md
+++ b/components/gantt/gantt-tree/templates/editor.md
@@ -245,7 +245,7 @@ In the Editor Template, you can data bind components to the current context, whi
         return Data.Where(i => item.Id.Equals(i.ParentId));
     }
 }
-````
+`````
 
 ## See Also
 

--- a/components/grid/columns/bound.md
+++ b/components/grid/columns/bound.md
@@ -138,12 +138,13 @@ You can use the following properties on bound columns:
 
 * The `Field` of the column must point to a property in the model that has a public getter so that the grid can display data. For editing to be enabled, the property must have a public setter. For example:
 
-    **C#**
-        public class MyModel
-        {
-            public int WorkinProperty { get; set; } // has public getter and setter so it can be shown and edited
-            public int NonWorkingField // no public getter, so the grid cannot display this
-        }
+    ````C#
+    public class MyModel
+    {
+        public int WorkinProperty { get; set; } // has public getter and setter so it can be shown and edited
+        public int NonWorkingField // no public getter, so the grid cannot display this
+    }
+    ````
 
 * **Foreign Keys** - using foreign tables and keys is usually done through the grid templates. You can read more and find examples in the [Grid - Foreign Key](slug:grids-foreign-key) KnowledgeBase article.
 

--- a/components/grid/sizing.md
+++ b/components/grid/sizing.md
@@ -24,7 +24,7 @@ You can increase or decrease the size of the Grid by setting the `Size` attribut
 
 >caption The built-in Size modes
 
-```CSHTML
+````CSHTML
 @* These are all built-in Size modes *@
 
 @{ 
@@ -51,7 +51,7 @@ You can increase or decrease the size of the Grid by setting the `Size` attribut
 @code {
     private IEnumerable<object> GridData = Enumerable.Range(1, 50).Select(x => new { ID = x, TheName = "name " + x });
 }
-```
+````
 
 ## Notes
 
@@ -61,7 +61,7 @@ You can increase or decrease the size of the Grid by setting the `Size` attribut
 
 >caption Set GridCommandButton Size option
 
-```CSHTML
+````CSHTML
 <TelerikGrid Size="@ThemeConstants.Grid.Size.Small"
              Data="@GridData"
 			 Height="350px">
@@ -80,7 +80,7 @@ You can increase or decrease the size of the Grid by setting the `Size` attribut
 @code {
 	private IEnumerable<object> GridData = Enumerable.Range(1, 50).Select(x => new { ID = x, TheName = "name " + x });
 }
-```
+````
 
 ## See Also
 

--- a/components/grid/smart-ai-features/ai-service-setup.md
+++ b/components/grid/smart-ai-features/ai-service-setup.md
@@ -52,17 +52,17 @@ Follow these steps to set up the Smart Extensions library in your .NET applicati
 
 Add the [`Telerik.AI.SmartComponents.Extensions` NuGet package](https://www.nuget.org/packages/Telerik.AI.SmartComponents.Extensions) to your project. It adds the following dependencies:
 
-```bash.skip-repl
+````bash.skip-repl
 dotnet add package Telerik.AI.SmartComponents.Extensions
 dotnet add package Microsoft.Extensions.AI
-```
+````
 
 Install your AI provider package. For Azure OpenAI:
 
-```bash.skip-repl
+````bash.skip-repl
 dotnet add package Azure.AI.OpenAI
 dotnet add package Microsoft.Extensions.AI.OpenAI
-```
+````
 
 ### Configure the AI Client
 

--- a/components/upload/initial-files.md
+++ b/components/upload/initial-files.md
@@ -17,7 +17,7 @@ To configure the initially displayed files, use the `Files` parameter of the Upl
 
 >caption Display initial files in Upload's list.
 
-```CSHTML
+````CSHTML
 
 <TelerikUpload Files="@InitialFiles" />
 
@@ -30,7 +30,7 @@ To configure the initially displayed files, use the `Files` parameter of the Upl
     };
 }
 
-```
+````
 
 ## Persist Selected Files
 
@@ -40,7 +40,7 @@ The Initial Files feature of the Upload allows you to save a list of files that 
 
 >caption How to load files and display them initially in the Upload
 
-```CSHTML
+````CSHTML
 
 @using System.IO;
 
@@ -78,7 +78,7 @@ The Initial Files feature of the Upload allows you to save a list of files that 
     }
 }
 
-```
+````
 
 
 ## See Also

--- a/components/upload/templates.md
+++ b/components/upload/templates.md
@@ -23,14 +23,14 @@ The `SelectFilesButtonTemplate` allows you to modify the **Select Files...** but
 
 >caption Using Upload SelectFilesButtonTemplate
 
-```RAZOR
+````RAZOR
 <TelerikUpload>
     <SelectFilesButtonTemplate>
         <TelerikSvgIcon Icon="@SvgIcon.Upload" />
         Click to Select Files for Upload
     </SelectFilesButtonTemplate>
 </TelerikUpload>
-```
+````
 
 ## FileTemplate
 
@@ -42,7 +42,7 @@ The example below demonstrates how to use the `RemoveFileAsync()` method to remo
 
 >caption Using Upload FileTemplate
 
-```RAZOR
+````RAZOR
 <TelerikUpload @ref="@UploadRef" Files="@InitialFiles">
     <FileTemplate Context="fileContext">
         <div class="custom-file-item">
@@ -105,7 +105,7 @@ The example below demonstrates how to use the `RemoveFileAsync()` method to remo
         UploadRef.RemoveFile(fileId);
     }
 }
-```
+````
 
 ## FileInfoTemplate
 
@@ -115,7 +115,7 @@ The `FileInfoTemplate` exposes a `context` of type `FileInfoTemplateContext` tha
 
 >caption Using Upload FileInfoTemplate
 
-```RAZOR
+````RAZOR
 <TelerikUpload Files="@InitialFiles">
     <FileInfoTemplate Context="fileContext">
         <strong>File Name:</strong> @fileContext.File.Name <br />
@@ -129,7 +129,7 @@ The `FileInfoTemplate` exposes a `context` of type `FileInfoTemplateContext` tha
         new UploadFileInfo(){ Id="1", Name="Report", Extension=".pdf", Size = 1024 * 1024 * 2 }
     };
 }
-```
+````
 
 ## See Also
 


### PR DESCRIPTION
Correct Markdown code-fence nesting across 10 Blazor documentation pages so embedded code snippets render and syntax-highlight correctly. No example content or behavior was changed.